### PR TITLE
feat: add interactive adventure state

### DIFF
--- a/thenoreal/app/page.tsx
+++ b/thenoreal/app/page.tsx
@@ -1,103 +1,91 @@
-import Image from "next/image";
+'use client';
+
+import { useState } from "react";
+
+type Option = {
+  text: string;
+  next: string;
+};
+
+type Scene = {
+  text: string;
+  options?: Option[];
+};
+
+const story: Record<string, Scene> = {
+  start: {
+    text: "Te despiertas en un bosque misterioso. ¿Qué haces?",
+    options: [
+      { text: "Caminar hacia la luz", next: "light" },
+      { text: "Explorar la oscuridad", next: "dark" },
+    ],
+  },
+  light: {
+    text: "Encuentras un pueblo tranquilo.",
+    options: [
+      { text: "Hablar con los aldeanos", next: "end" },
+      { text: "Continuar tu viaje", next: "end" },
+    ],
+  },
+  dark: {
+    text: "Una criatura aparece y te asusta.",
+    options: [
+      { text: "Huir", next: "end" },
+      { text: "Enfrentarte a la criatura", next: "end" },
+    ],
+  },
+  end: {
+    text: "La aventura termina aquí.",
+  },
+};
+
+const initialScene = story.start;
 
 export default function Home() {
-  return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [history, setHistory] = useState<string[]>([initialScene.text]);
+  const [options, setOptions] = useState<Option[]>(initialScene.options ?? []);
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
+  const handleOption = (option: Option) => {
+    const nextScene = story[option.next];
+    setHistory((h) => [...h, option.text, nextScene.text]);
+    setOptions(nextScene.options ?? []);
+  };
+
+  const resetAdventure = () => {
+    setHistory([initialScene.text]);
+    setOptions(initialScene.options ?? []);
+  };
+
+  return (
+    <main className="p-8">
+      <section className="mb-4 space-y-2">
+        {history.map((line, idx) => (
+          <p key={idx}>{line}</p>
+        ))}
+      </section>
+
+      <div className="flex flex-col gap-2">
+        {options.map((opt) => (
+          <button
+            key={opt.text}
+            onClick={() => handleOption(opt)}
+            className="px-4 py-2 bg-blue-500 text-white rounded"
           >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+            {opt.text}
+          </button>
+        ))}
+        {options.length === 0 && (
+          <p className="italic">No hay más opciones.</p>
+        )}
+      </div>
+
+      <button
+        onClick={resetAdventure}
+        className="mt-6 underline text-sm text-blue-700"
+      >
+        Reiniciar
+      </button>
+    </main>
   );
 }
+


### PR DESCRIPTION
## Summary
- use `useState` to track adventure history and available options
- add reset button to restart the story by clearing state
- provide simple branching story data structure

## Testing
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a154d00a808329aa5d71b4a9f0ed24