### PR TITLE
feat: add Groq API key configuration

### DIFF
--- a/thenoreal/.env.local
+++ b/thenoreal/.env.local
@@ -1,0 +1,1 @@
+GROQ_API_KEY=your_groq_api_key_here

--- a/thenoreal/.gitignore
+++ b/thenoreal/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local
 
 # vercel
 .vercel

--- a/thenoreal/README.md
+++ b/thenoreal/README.md
@@ -20,6 +20,16 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Variables de entorno
+
+Para utilizar la API de Groq, define la variable `GROQ_API_KEY` en un archivo `.env.local` en la raíz del proyecto:
+
+```bash
+GROQ_API_KEY=tu_token_de_groq
+```
+
+Next.js cargará automáticamente esta variable y estará disponible como `process.env.GROQ_API_KEY` dentro de las rutas de la API.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/thenoreal/app/api/groq/route.ts
+++ b/thenoreal/app/api/groq/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const apiKey = process.env.GROQ_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "GROQ_API_KEY is not defined" },
+      { status: 500 }
+    );
+  }
+
+  // Example usage: the key could be used to call Groq's API here.
+  return NextResponse.json({ message: "GROQ_API_KEY loaded" });
+}


### PR DESCRIPTION
## Summary
- commit `.env.local` placeholder for `GROQ_API_KEY`
- expose new `GET /api/groq` route that reads `GROQ_API_KEY`
- document how to configure `GROQ_API_KEY` in README

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (prompts for ESLint config)

------
https://chatgpt.com/codex/tasks/task_e_68a154d1a2f08329acecf915ee3bcd11