### PR TITLE
Validate option count and handle API errors

### DIFF
--- a/thenoreal/app/api/options/route.ts
+++ b/thenoreal/app/api/options/route.ts
@@ -2,19 +2,38 @@ import Groq from "groq-sdk";
 
 const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
 
+const MAX_OPTIONS = 5;
+
 export async function POST(req: Request) {
-  const { prompt, numOptions } = await req.json();
+  try {
+    const { prompt, numOptions } = await req.json();
 
-  const completion = await groq.chat.completions.create({
-    model: "llama3-8b-8192",
-    messages: [{ role: "user", content: prompt }],
-    n: numOptions ?? 1,
-  });
+    const count = Number(numOptions) || 1;
+    if (count > MAX_OPTIONS) {
+      return Response.json(
+        { error: `numOptions cannot exceed ${MAX_OPTIONS}` },
+        { status: 400 }
+      );
+    }
 
-  const options = completion.choices
-    .map((c) => c.message?.content?.trim())
-    .filter(Boolean);
+    const completions = await Promise.all(
+      Array.from({ length: count }).map(() =>
+        groq.chat.completions.create({
+          model: "llama3-8b-8192",
+          messages: [{ role: "user", content: prompt }],
+          n: 1,
+        })
+      )
+    );
 
-  return Response.json({ options });
+    const options = completions
+      .map((c) => c.choices[0]?.message?.content?.trim())
+      .filter(Boolean);
+
+    return Response.json({ options });
+  } catch (err) {
+    console.error(err);
+    return Response.json({ error: "Error generating options" }, { status: 500 });
+  }
 }
 

--- a/thenoreal/app/page.tsx
+++ b/thenoreal/app/page.tsx
@@ -7,9 +7,11 @@ export default function Home() {
   const [numOptions, setNumOptions] = useState(1);
   const [options, setOptions] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const generate = async () => {
     setLoading(true);
+    setError(null);
     try {
       const res = await fetch("/api/options", {
         method: "POST",
@@ -17,9 +19,16 @@ export default function Home() {
         body: JSON.stringify({ prompt, numOptions }),
       });
       const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Error generating options");
+        setOptions([]);
+        return;
+      }
       setOptions(data.options || []);
     } catch (err) {
       console.error(err);
+      setError("Error connecting to the API");
+      setOptions([]);
     } finally {
       setLoading(false);
     }
@@ -39,6 +48,7 @@ export default function Home() {
           id="numOptions"
           type="number"
           min={1}
+          max={5}
           value={numOptions}
           onChange={(e) => setNumOptions(Number(e.target.value))}
           className="border p-1 w-20"
@@ -51,6 +61,7 @@ export default function Home() {
       >
         {loading ? "Generando..." : "Generar"}
       </button>
+      {error && <p className="text-red-500">{error}</p>}
       <ul className="list-disc mt-4">
         {options.map((o, i) => (
           <li key={i}>{o}</li>


### PR DESCRIPTION
## Summary
- Validate `numOptions` and limit option generation to five per request
- Aggregate multiple `groq.chat.completions.create` calls to build the options list
- Surface API errors in the UI and show a friendly message when the option limit is exceeded

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requested ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a1628ea21883298e811346d43feb9f