### PR TITLE
Add server-side Groq story endpoint and use it in Story component

### DIFF
--- a/thenoreal/app/api/story/route.ts
+++ b/thenoreal/app/api/story/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import Groq from "groq-sdk";
+
+const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
+
+export async function POST(req: Request) {
+  if (!process.env.GROQ_API_KEY) {
+    return NextResponse.json(
+      { error: "GROQ_API_KEY is not defined" },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const { story, option } = await req.json();
+
+    const completion = await groq.chat.completions.create({
+      model: "mixtral-8x7b-32768",
+      messages: [
+        { role: "system", content: "Eres un generador de historias ramificadas." },
+        { role: "user", content: `${story}\n\nOpción elegida: ${option}` },
+      ],
+    });
+
+    const text = completion.choices?.[0]?.message?.content || "";
+
+    return NextResponse.json({ text });
+  } catch (error) {
+    console.error("Error al consultar la API de Groq", error);
+    return NextResponse.json({ error: "Error al consultar la API de Groq" }, { status: 500 });
+  }
+}

--- a/thenoreal/app/components/Story.tsx
+++ b/thenoreal/app/components/Story.tsx
@@ -22,22 +22,15 @@ export default function Story({ initialStory, initialOptions }: StoryProps) {
   const handleSelect = async (option: string) => {
     setLoading(true);
     try {
-      const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+      const response = await fetch('/api/story', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${process.env.NEXT_PUBLIC_GROQ_API_KEY}`,
         },
-        body: JSON.stringify({
-          model: 'mixtral-8x7b-32768',
-          messages: [
-            { role: 'system', content: 'Eres un generador de historias ramificadas.' },
-            { role: 'user', content: `${story}\n\nOpción elegida: ${option}` },
-          ],
-        }),
+        body: JSON.stringify({ story, option }),
       });
       const data = await response.json();
-      const text = data.choices?.[0]?.message?.content || '';
+      const text = data.text || '';
       const lines = text.split('\n').filter(Boolean);
       const [newStory, ...newOptions] = lines;
 


### PR DESCRIPTION
## Summary
- add `/api/story` API route that uses server-side `GROQ_API_KEY` to call Groq and return generated text
- update `Story` component to fetch story updates from new internal API

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=1 npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a16293247083299d18048c7794bf62