### PR TITLE
feat: add story config validator

### DIFF
--- a/lib/validateStoryConfig.ts
+++ b/lib/validateStoryConfig.ts
@@ -1,0 +1,35 @@
+export enum EndingMode {
+  REQUERIDO = 'requerido',
+  PERMITIDO = 'permitido',
+  PROHIBIDO = 'prohibido'
+}
+
+export interface StoryConfig {
+  opciones_por_decision: number;
+  final: EndingMode;
+  capitulos?: unknown;
+}
+
+export function validateStoryConfig(config: StoryConfig): string | null {
+  const { opciones_por_decision, final, capitulos } = config;
+
+  if (!Number.isInteger(opciones_por_decision) || opciones_por_decision < 2) {
+    return 'opciones_por_decision debe ser un entero mayor o igual a 2';
+  }
+
+  if (!Object.values(EndingMode).includes(final)) {
+    return `final debe ser uno de los siguientes valores: ${Object.values(EndingMode).join(', ')}`;
+  }
+
+  if (final === EndingMode.REQUERIDO && capitulos === undefined) {
+    return 'capitulos es requerido cuando final es "requerido"';
+  }
+
+  if (final === EndingMode.PROHIBIDO && capitulos !== undefined) {
+    return 'capitulos está prohibido cuando final es "prohibido"';
+  }
+
+  return null;
+}
+
+export default validateStoryConfig;


### PR DESCRIPTION
## Summary
- define `EndingMode` enum and `StoryConfig` interface
- add `validateStoryConfig` function validating decisions, endings, and chapters

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: How would you like to configure ESLint?)


------
https://chatgpt.com/codex/tasks/task_e_68a168539f448329a44266b9436ba902