### PR TITLE
feat: add stories API route

### DIFF
--- a/thenoreal/app/api/stories/route.ts
+++ b/thenoreal/app/api/stories/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import { StoryConfig, validateStoryConfig } from '@/lib/story-config';
+
+export async function POST(req: Request) {
+  let data: unknown;
+  try {
+    data = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  if (!validateStoryConfig(data)) {
+    return NextResponse.json({ error: 'Invalid story config' }, { status: 400 });
+  }
+
+  try {
+    const story = await prisma.story.create({ data: data as StoryConfig });
+    return NextResponse.json(story);
+  } catch (err) {
+    console.error('Error creating story', err);
+    return NextResponse.json({ error: 'Failed to create story' }, { status: 500 });
+  }
+}

--- a/thenoreal/lib/prisma.ts
+++ b/thenoreal/lib/prisma.ts
@@ -1,0 +1,14 @@
+import { PrismaClient } from '@prisma/client';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+const prisma = global.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  global.prisma = prisma;
+}
+
+export default prisma;

--- a/thenoreal/lib/story-config.ts
+++ b/thenoreal/lib/story-config.ts
@@ -1,0 +1,10 @@
+export interface StoryConfig {
+  title: string;
+  content: string;
+}
+
+export function validateStoryConfig(data: unknown): data is StoryConfig {
+  if (typeof data !== 'object' || data === null) return false;
+  const { title, content } = data as Record<string, unknown>;
+  return typeof title === 'string' && typeof content === 'string';
+}

--- a/thenoreal/package.json
+++ b/thenoreal/package.json
@@ -14,7 +14,8 @@
     "next-pwa": "^5.6.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "workbox-window": "^7.3.0"
+    "workbox-window": "^7.3.0",
+    "@prisma/client": "^6.14.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -22,6 +23,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "prisma": "^6.14.0"
   }
 }


### PR DESCRIPTION
## Summary
- add POST /api/stories route to validate input and persist stories with Prisma
- create StoryConfig type and validator
- set up Prisma client and dependencies

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: interactive ESLint setup prompt)


------
https://chatgpt.com/codex/tasks/task_e_68a16854e54083298272327a5834eb09