### PR TITLE
feat: add groq client wrapper

### DIFF
--- a/app/api/options/route.ts
+++ b/app/api/options/route.ts
@@ -1,6 +1,4 @@
-import Groq from "groq-sdk";
-
-const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
+import createChatCompletion from "@/lib/groqClient";
 
 const MAX_OPTIONS = 5;
 
@@ -18,7 +16,7 @@ export async function POST(req: Request) {
 
     const completions = await Promise.all(
       Array.from({ length: count }).map(() =>
-        groq.chat.completions.create({
+        createChatCompletion({
           model: "llama3-8b-8192",
           messages: [{ role: "user", content: prompt }],
           n: 1,

--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
-import Groq from "groq-sdk";
-
-const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
+import createChatCompletion from "@/lib/groqClient";
 
 export async function POST(req: Request) {
   if (!process.env.GROQ_API_KEY) {
@@ -14,7 +12,7 @@ export async function POST(req: Request) {
   try {
     const { story, option, optionsPerDecision } = await req.json();
 
-    const completion = await groq.chat.completions.create({
+    const completion = await createChatCompletion({
       model: "openai/gpt-oss-120b",
       messages: [
         {

--- a/lib/groqClient.ts
+++ b/lib/groqClient.ts
@@ -1,0 +1,37 @@
+import Groq from 'groq-sdk';
+
+const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
+
+function filterSensitive(data: unknown): unknown {
+  const secret = process.env.GROQ_API_KEY;
+  if (!secret) return data;
+  if (typeof data === 'string') {
+    return data.replace(new RegExp(secret, 'g'), '[REDACTED]');
+  }
+  if (Array.isArray(data)) {
+    return data.map(filterSensitive);
+  }
+  if (data && typeof data === 'object') {
+    return Object.fromEntries(
+      Object.entries(data as Record<string, unknown>).map(([k, v]) => [
+        k,
+        filterSensitive(v),
+      ])
+    );
+  }
+  return data;
+}
+
+export async function createChatCompletion(
+  params: Parameters<typeof groq.chat.completions.create>[0]
+) {
+  console.log('groq.chat.completions.create called', {
+    model: params.model,
+    messages: filterSensitive(params.messages),
+  });
+  const result = await groq.chat.completions.create(params);
+  console.log('groq.chat.completions.create result', filterSensitive(result));
+  return result;
+}
+
+export default createChatCompletion;


### PR DESCRIPTION
## Summary
- add reusable Groq chat completion client with logging and sanitization
- refactor story and options API routes to use Groq client

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a25558b9a48329af4131505f6c2c33