### PR TITLE
chore: clean up env configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-# Environment variables declared in this file are automatically made available to Prisma.
-# See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
-
-# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
-# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
-
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/thenoreal"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/thenoreal"
+GROQ_API_KEY="your-groq-api-key"

--- a/.env.local
+++ b/.env.local
@@ -1,1 +1,0 @@
-GROQ_API_KEY=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

--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,10 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
-.env*
-!.env.local
+# env files
+.env
+.env.*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
 
+## Environment variables
+
+Copy the example file and provide your own values:
+
+```bash
+cp .env.example .env.local
+```
+
+Set `GROQ_API_KEY` to a valid token from Groq (the previously committed key has been revoked) and update `DATABASE_URL` for your database. ` .env.local` is ignored by git and should not be committed.
+
+Next.js will load variables from `.env.local` in development. For deployments, configure these environment variables through your hosting provider.
+
 ## Cargar la PWA en React Native/Expo
 
 Para empaquetar esta PWA dentro de una app móvil:


### PR DESCRIPTION
## Summary
- stop tracking `.env` files and add example env template
- document environment variable usage and revoked `GROQ_API_KEY`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx --yes jest --passWithNoTests` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2555cb3ec832991272d088e5ec220