### PR TITLE
feat: improve Groq completion typing

### DIFF
--- a/app/api/options/route.ts
+++ b/app/api/options/route.ts
@@ -25,7 +25,9 @@ export async function POST(req: Request) {
     );
 
     const options = completions
-      .map((c) => c.choices[0]?.message?.content?.trim())
+      .map((c) =>
+        'choices' in c ? c.choices[0]?.message?.content?.trim() : undefined
+      )
       .filter(Boolean);
 
     return Response.json({ options });

--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -27,7 +27,10 @@ export async function POST(req: Request) {
       ],
     });
 
-    const text = completion.choices?.[0]?.message?.content || "";
+    const text =
+      'choices' in completion
+        ? completion.choices?.[0]?.message?.content || ""
+        : "";
 
     return NextResponse.json({ text });
   } catch (error) {

--- a/lib/groqClient.ts
+++ b/lib/groqClient.ts
@@ -1,4 +1,9 @@
 import Groq from 'groq-sdk';
+import type {
+  ChatCompletion,
+  ChatCompletionChunk,
+} from 'groq-sdk/resources/chat/completions';
+import type { Stream } from 'groq-sdk/lib/streaming';
 
 const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
 
@@ -22,6 +27,12 @@ function filterSensitive(data: unknown): unknown {
   return data;
 }
 
+export async function createChatCompletion(
+  params: { stream: true } & Parameters<typeof groq.chat.completions.create>[0]
+): Promise<Stream<ChatCompletionChunk>>;
+export async function createChatCompletion(
+  params: { stream?: false } & Parameters<typeof groq.chat.completions.create>[0]
+): Promise<ChatCompletion>;
 export async function createChatCompletion(
   params: Parameters<typeof groq.chat.completions.create>[0]
 ) {


### PR DESCRIPTION
## Summary
- type the `createChatCompletion` wrapper to return `ChatCompletion` or stream chunks
- guard API handlers when reading completion choices

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '../storyConfig', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a25d1ba718832997b75bc787c372d8