### PR TITLE
feat: add pastel narrative palette

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,10 @@
 @import "tailwindcss";
 
+/* Pastel narrative palette: lavender base with blush accents */
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #f5e9ff; /* soft lavender */
+  --foreground: #3a2d4f; /* deep plum for readability */
+  --accent: #ffd6e7; /* blush pink accent */
 }
 
 @theme inline {
@@ -14,13 +16,15 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    /* Dimmed pastel palette */
+    --background: #1a1622; /* midnight violet */
+    --foreground: #f1e9f9; /* pale orchid text */
+    --accent: #b388eb; /* muted violet accent */
   }
 }
 
 body {
-  background: var(--background);
+  background: linear-gradient(135deg, var(--background), var(--accent));
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
## Summary
- add pastel narrative color variables to global styles
- apply lavender-to-blush gradient background using new palette

## Testing
- `npx jest`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a273d21e648329bbb37848f2cfa0d7