### PR TITLE
feat: improve accent color contrast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,7 +4,7 @@
 :root {
   --background: #f5e9ff; /* soft lavender */
   --foreground: #3a2d4f; /* deep plum for readability */
-  --accent: #ffd6e7; /* blush pink accent */
+  --accent: #c13870; /* deep rose accent for better contrast */
 }
 
 @theme inline {
@@ -19,7 +19,7 @@
     /* Dimmed pastel palette */
     --background: #1a1622; /* midnight violet */
     --foreground: #f1e9f9; /* pale orchid text */
-    --accent: #b388eb; /* muted violet accent */
+    --accent: #8b5abb; /* rich violet accent for better contrast */
   }
 }
 


### PR DESCRIPTION
## Summary
- darken accent color for better contrast in light and dark themes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68a27e9380ec8329b1b325778309dbc1