### PR TITLE
feat: update accent colors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,11 +1,11 @@
 @import "tailwindcss";
 
-/* Pastel narrative palette: lavender base with blush accents */
+/* Pastel narrative palette: lavender base with mint accents */
 :root {
   --background: #f5e9ff; /* soft lavender */
   --foreground: #3a2d4f; /* deep plum for readability */
-  --accent: #ffd6e7; /* blush pink accent */
-  --accent-dark: #ff9fc6; /* deeper blush accent */
+  --accent: #c3f0ca; /* mint green accent */
+  --accent-dark: #5dbb63; /* deeper mint accent */
 }
 
 @theme inline {
@@ -22,8 +22,8 @@
     /* Dimmed pastel palette */
     --background: #1a1622; /* midnight violet */
     --foreground: #f1e9f9; /* pale orchid text */
-    --accent: #b388eb; /* muted violet accent */
-    --accent-dark: #8c62c4; /* deeper violet accent */
+    --accent: #5dbb63; /* muted mint accent */
+    --accent-dark: #2f855a; /* deeper mint accent */
   }
 }
 


### PR DESCRIPTION
## Summary
- refresh accent palette to mint tones in global styles

## Testing
- `npm run dev`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a28da447688329ac843a0f58a34855