### PR TITLE
feat: make SD image endpoint configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Example environment variables
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/thenoreal"
 GROQ_API_KEY="your-groq-api-key"
+NEXT_PUBLIC_SD_API="https://example.com/api/sd/generate"

--- a/lib/imageGenerator.ts
+++ b/lib/imageGenerator.ts
@@ -1,7 +1,7 @@
-const ENDPOINT = 'https://tbhvrp51-8000.brs.devtunnels.ms/generate';
+const SD_API = process.env.NEXT_PUBLIC_SD_API ?? '/api/sd/generate';
 
 export async function generateImage(prompt: string): Promise<string> {
-  const res = await fetch(ENDPOINT, {
+  const res = await fetch(SD_API, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({


### PR DESCRIPTION
## Summary
- read `NEXT_PUBLIC_SD_API` for image generation endpoint with fallback
- document `NEXT_PUBLIC_SD_API` in `.env.example`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68a29d1f41808329bc2da823eae88cdd