### PR TITLE
Generate images for new chapters with error handling

### DIFF
--- a/app/components/Story.tsx
+++ b/app/components/Story.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { generateImage } from '@/lib/imageGenerator';
 
 interface StoryProps {
   /** Texto inicial de la historia */
@@ -65,6 +66,15 @@ export default function Story({
 
       setStory((prev) => `${prev}\n\n${newStory}`);
       setCurrentChapter(nextChapter);
+
+      try {
+        const url = await generateImage(newStory);
+        setImageSrc(url);
+      } catch (err) {
+        console.error('Error al generar la imagen', err);
+        setImageSrc(null);
+        alert('No se pudo generar la imagen');
+      }
 
       let opts = newOptions.slice(0, optionsPerDecision);
       let end = false;


### PR DESCRIPTION
## Summary
- call `generateImage` for each new chapter selection
- display generated image and show message when generation fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a29d221e208329a911fd99924d599c