### PR TITLE
Add genre selection to story creation

### DIFF
--- a/app/components/Story.tsx
+++ b/app/components/Story.tsx
@@ -14,6 +14,8 @@ interface StoryProps {
   endingMode: 'capitulos' | 'final_sorpresa' | 'sin_final_definido' | 'infinita';
   /** Número máximo de capítulos (opcional) */
   chaptersCount?: number;
+  /** Géneros seleccionados */
+  genres: string[];
 }
 
 interface HistoryEntry {
@@ -33,6 +35,7 @@ export default function Story({
   optionsPerDecision,
   endingMode,
   chaptersCount,
+  genres,
 }: StoryProps) {
   const [story, setStory] = useState(initialStory);
   const [options, setOptions] = useState(
@@ -57,7 +60,7 @@ export default function Story({
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ story, option, optionsPerDecision }),
+        body: JSON.stringify({ story, option, optionsPerDecision, genres }),
       });
       const data = await response.json();
       const text = data.text || '';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,16 @@ const MODALITY_HELP = {
 
 type Modality = keyof typeof MODALITY_HELP;
 
+const GENRES = [
+  "Aventura",
+  "Ciencia ficción",
+  "Terror",
+  "Fantasía",
+  "Misterio",
+  "Romance",
+  "Comedia",
+];
+
 export default function Home() {
   const [prompt, setPrompt] = useState("");
   const [numOptions, setNumOptions] = useState(2);
@@ -32,9 +42,21 @@ export default function Home() {
     endingMode: EndingMode;
     chaptersCount?: number;
   } | null>(null);
+  const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
+  const [showGenreSelector, setShowGenreSelector] = useState(false);
 
   const showChapters =
     modality === "capitulos" || modality === "final_sorpresa";
+
+  const toggleGenre = (genre: string) => {
+    setSelectedGenres((prev) =>
+      prev.includes(genre)
+        ? prev.filter((g) => g !== genre)
+        : [...prev, genre]
+    );
+  };
+
+  const clearGenres = () => setSelectedGenres([]);
 
   const handleSubmit = async () => {
     setLoading(true);
@@ -58,6 +80,7 @@ export default function Home() {
         prompt,
         opciones_por_decision: Number(numOptions),
         final,
+        genres: selectedGenres,
         ...((final === "capitulos" || final === "final_sorpresa") && chapters
           ? { capitulos: Number(chapters) }
           : {}),
@@ -81,6 +104,7 @@ export default function Home() {
             story: prompt,
             option: "",
             optionsPerDecision: Number(numOptions),
+            genres: selectedGenres,
           }),
         });
         const storyData = await storyRes.json().catch(() => ({}));
@@ -165,6 +189,46 @@ export default function Home() {
             </div>
           )}
           <button
+            type="button"
+            onClick={() => setShowGenreSelector((prev) => !prev)}
+            className="px-4 py-2 rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark transition-colors"
+          >
+            {showGenreSelector ? "Cerrar géneros" : "Seleccionar géneros"}
+          </button>
+          {showGenreSelector && (
+            <div className="flex flex-col gap-2 p-4 border border-black/30 rounded-lg max-w-xl w-full">
+              {GENRES.map((genre) => (
+                <label key={genre} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={selectedGenres.includes(genre)}
+                    onChange={() => toggleGenre(genre)}
+                  />
+                  {genre}
+                </label>
+              ))}
+              <button
+                type="button"
+                onClick={clearGenres}
+                className="self-start px-2 py-1 mt-2 text-sm rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark"
+              >
+                Limpiar
+              </button>
+            </div>
+          )}
+          {selectedGenres.length > 0 && (
+            <div className="flex flex-wrap gap-2 max-w-xl">
+              {selectedGenres.map((genre) => (
+                <span
+                  key={genre}
+                  className="px-2 py-1 text-sm rounded-full bg-accent text-black"
+                >
+                  {genre}
+                </span>
+              ))}
+            </div>
+          )}
+          <button
             onClick={handleSubmit}
             disabled={loading}
             className="px-4 py-2 rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark transition-colors focus:outline-none focus:ring-2 focus:ring-accent disabled:opacity-50"
@@ -180,6 +244,7 @@ export default function Home() {
           optionsPerDecision={storyConfig.optionsPerDecision}
           endingMode={storyConfig.endingMode}
           chaptersCount={storyConfig.chaptersCount}
+          genres={selectedGenres}
         />
       )}
       {error && <p className="text-red-500">{error}</p>}


### PR DESCRIPTION
## Summary
- add genre selector with chips and clear button
- include genres in story payloads and pass to Story component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx jest` *(fails: Preset ts-jest not found)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ad6354148329b6fc6f6e68c58fb1