### PR TITLE
feat: add genre support to story prompt

### DIFF
--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -10,15 +10,26 @@ export async function POST(req: Request) {
   }
 
   try {
-    const { story, option, optionsPerDecision } = await req.json();
+    const { story, option, optionsPerDecision, genres } = await req.json();
+
+    const genreLine =
+      Array.isArray(genres) && genres.length > 0
+        ? `Géneros a respetar: ${genres.join(', ')}.`
+        : '';
+
+    const systemPrompt = [
+      "Eres un generador de historias ramificadas. Responde con el siguiente capítulo seguido de las opciones solicitadas, cada una en una línea.",
+      genreLine,
+    ]
+      .filter(Boolean)
+      .join("\n\n");
 
     const completion = await createChatCompletion({
       model: "openai/gpt-oss-120b",
       messages: [
         {
           role: "system",
-          content:
-            "Eres un generador de historias ramificadas. Responde con el siguiente capítulo seguido de las opciones solicitadas, cada una en una línea.",
+          content: systemPrompt,
         },
         {
           role: "user",


### PR DESCRIPTION
## Summary
- parse `genres` from story request
- append genre line to system prompt for Groq chat completion

## Testing
- `npx jest`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ad683e7483298cc20e36b9fd0d04