### PR TITLE
feat: add genre-based image styling

### DIFF
--- a/lib/imageGenerator.ts
+++ b/lib/imageGenerator.ts
@@ -2,13 +2,29 @@ const env = process.env.NEXT_PUBLIC_SD_API?.trim();
 // Si NO hay env, usamos el proxy de Next:
 const SD_API = env && env.length > 0 ? env : '/api/sd/generate';
 
-export async function generateImage(prompt: string): Promise<string> {
-  const finalPrompt = `${prompt}\n\nEstilo: tinta minimalista, fondo blanco, el dibujo tiene que interpretar la historia relatada en el prompt`;
+export const GENRE_STYLE: Record<string, string> = {
+  fantasy: 'fantasía épica',
+  scifi: 'ciencia ficción futurista',
+  horror: 'horror oscuro',
+  romance: 'romance suave',
+};
+
+const BASE_STYLE =
+  'tinta minimalista, fondo blanco, el dibujo tiene que interpretar la historia relatada en el prompt';
+
+export async function generateImage(
+  prompt: string,
+  genres: string[] = []
+): Promise<string> {
+  const finalPromptImagen = `${prompt}. Estilo visual: ${[
+    BASE_STYLE,
+    ...genres.map((g) => GENRE_STYLE[g] ?? g),
+  ].join(', ')}`;
   const res = await fetch(SD_API, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      prompt,
+      prompt: finalPromptImagen,
       engine: 'sdxl-turbo',
       width: 512,
       height: 512,


### PR DESCRIPTION
## Summary
- allow passing genres to image generator and map them to descriptive styles
- send composed prompt with genre styles to Stable Diffusion API

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ad69d6f88329be2548368ab04c65