### PR TITLE
feat: add timeout for image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ cp .env.example .env.local
 
 Set `GROQ_API_KEY` to a valid token from Groq (the previously committed key has been revoked) and update `DATABASE_URL` for your database. ` .env.local` is ignored by git and should not be committed.
 
+You can also define `NEXT_PUBLIC_IMAGE_TIMEOUT` (in milliseconds) to control how long the app waits for image generation before aborting and continuing without an image. It defaults to `15000`.
+
 Next.js will load variables from `.env.local` in development. For deployments, configure these environment variables through your hosting provider.
 
 ## Cargar la PWA en React Native/Expo

--- a/app/components/Story.tsx
+++ b/app/components/Story.tsx
@@ -72,7 +72,11 @@ export default function Story({
 
       try {
         const url = await generateImage(newStory, genres);
-        setImageSrc(url);
+        if (url) {
+          setImageSrc(url);
+        } else {
+          setImageSrc(null);
+        }
       } catch (err) {
         console.error('Error al generar la imagen, No se pudo generar la imagen', err);
         setImageSrc(null);

--- a/lib/imageGenerator.ts
+++ b/lib/imageGenerator.ts
@@ -4,46 +4,65 @@ const SD_API = env && env.length > 0 ? env : '/api/sd/generate';
 
 export async function generateImage(
   prompt: string,
-  genres: string[] = []
-): Promise<string> {
+  genres: string[] = [],
+  timeoutMs: number = Number(process.env.NEXT_PUBLIC_IMAGE_TIMEOUT) || 15000
+): Promise<string | null> {
   const genrePrompt = genres.length > 0 ? `\nGéneros: ${genres.join(', ')}` : '';
   const finalPrompt = `${prompt}${genrePrompt}\n\nEstilo: tinta minimalista, fondo blanco, el dibujo tiene que interpretar la historia relatada en el prompt`;
-  const res = await fetch(SD_API, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      prompt: finalPrompt,
-      engine: 'sdxl-turbo',
-      width: 512,
-      height: 512,
-      steps: 10,
-    }),
-  });
 
-  if (!res.ok) {
-    throw new Error(`Image generation failed: ${res.status} ${res.statusText}`);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(SD_API, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt: finalPrompt,
+        engine: 'sdxl-turbo',
+        width: 512,
+        height: 512,
+        steps: 10,
+      }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      throw new Error(`Image generation failed: ${res.status} ${res.statusText}`);
+    }
+
+    const data = await res.json();
+
+    // Compat con múltiples “shapes”
+    const url =
+      data?.data?.[0]?.url || // OpenAI-style (proxy)
+      data?.image_url || // data URL directo (proxy)
+      data?.url ||
+      data?.image ||
+      (Array.isArray(data?.images)
+        ? typeof data.images[0] === 'string'
+          ? data.images[0]
+          : data.images[0]?.url
+        : undefined) ||
+      (Array.isArray(data?.output)
+        ? typeof data.output[0] === 'string'
+          ? data.output[0]
+          : data.output[0]?.url
+        : undefined) ||
+      (data?.image_base64
+        ? `data:image/png;base64,${data.image_base64}` // FastAPI directo
+        : undefined);
+
+    if (!url) throw new Error('Image URL not found in response');
+    return url;
+  } catch (error: any) {
+    if (error.name === 'AbortError') {
+      return null; // Aborted by timeout
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
   }
-
-  const data = await res.json();
-
-  // Compat con múltiples “shapes”
-  const url =
-    data?.data?.[0]?.url ||                // OpenAI-style (proxy)
-    data?.image_url ||                      // data URL directo (proxy)
-    data?.url ||
-    data?.image ||
-    (Array.isArray(data?.images)
-      ? (typeof data.images[0] === 'string' ? data.images[0] : data.images[0]?.url)
-      : undefined) ||
-    (Array.isArray(data?.output)
-      ? (typeof data.output[0] === 'string' ? data.output[0] : data.output[0]?.url)
-      : undefined) ||
-    (data?.image_base64
-      ? `data:image/png;base64,${data.image_base64}` // FastAPI directo
-      : undefined);
-
-  if (!url) throw new Error('Image URL not found in response');
-  return url;
 }
 
 export default generateImage;


### PR DESCRIPTION
## Summary
- allow setting a timeout for image generation via `NEXT_PUBLIC_IMAGE_TIMEOUT`
- abort image fetches after timeout and return null
- handle missing images in Story component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a3402c0bd48329b146c83da602b2b2