### PR TITLE
Propagate selected genres to story flow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,6 @@ export default function Home() {
   const [numOptions, setNumOptions] = useState(2);
   const [modality, setModality] = useState<Modality>("capitulos");
   const [chapters, setChapters] = useState("");
-  const [genres] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [initialStory, setInitialStory] = useState<string | null>(null);
@@ -105,8 +104,7 @@ export default function Home() {
             story: prompt,
             option: "",
             optionsPerDecision: Number(numOptions),
-            genres//,
-            //genres: selectedGenres,
+            genres: selectedGenres,
           }),
         });
         const storyData = await storyRes.json().catch(() => ({}));
@@ -246,8 +244,7 @@ export default function Home() {
           optionsPerDecision={storyConfig.optionsPerDecision}
           endingMode={storyConfig.endingMode}
           chaptersCount={storyConfig.chaptersCount}
-          genres={genres}
-          //genres={selectedGenres}
+          genres={selectedGenres}
         />
       )}
       {error && <p className="text-red-500">{error}</p>}


### PR DESCRIPTION
## Summary
- Remove unused `genres` state from home page
- Include selected genres when requesting `/api/story`
- Pass chosen genres to `Story` component for downstream calls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: Environment variable not found: DATABASE_URL_UNPOOLED)*

------
https://chatgpt.com/codex/tasks/task_e_68a35cbb915c8329955c3473ceb80a95