### PR TITLE
style: center and constrain story image

### DIFF
--- a/app/components/Story.tsx
+++ b/app/components/Story.tsx
@@ -132,12 +132,12 @@ export default function Story({
       <p className="whitespace-pre-line">{story}</p>
       <div className="flex flex-col gap-2 rounded-lg">
         {imageSrc && (
-        <img
-          src={imageSrc}
-          alt="Imagen generada"
-          className="mt-4 rounded-lg border border-black/30"
-        />
-      )}
+          <img
+            src={imageSrc}
+            alt="Imagen generada"
+            className="mx-auto my-4 max-w-md rounded-lg border border-black/30"
+          />
+        )}
         <button
           onClick={handleBack}
           disabled={history.length === 0 || loading}


### PR DESCRIPTION
## Summary
- center story images and limit width for better layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for configuration, canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68a36d4b1b0c832998642126b8bcacde