### PR TITLE
feat: truncate image prompts at 77 tokens

### DIFF
--- a/app/components/Story.tsx
+++ b/app/components/Story.tsx
@@ -88,8 +88,14 @@ export default function Story({
       const [newStory, ...newOptions] = lines;
 
       let imageUrl: string | null = null;
+      let promptTruncated = false;
       try {
-        imageUrl = await generateImage(newStory, genres);
+        const { url, truncated } = await generateImage(newStory, genres);
+        imageUrl = url;
+        promptTruncated = truncated;
+        if (promptTruncated) {
+          console.warn('El prompt para la imagen fue truncado a 77 tokens');
+        }
       } catch (err) {
         console.error('Error al generar la imagen, No se pudo generar la imagen', err);
       }

--- a/lib/imageGenerator.ts
+++ b/lib/imageGenerator.ts
@@ -2,13 +2,26 @@ const env = process.env.NEXT_PUBLIC_SD_API?.trim();
 // Si NO hay env, usamos el proxy de Next:
 const SD_API = env && env.length > 0 ? env : '/api/sd/generate';
 
+export function truncatePrompt(
+  prompt: string,
+  maxTokens: number = 77
+): { text: string; truncated: boolean } {
+  const tokens = prompt.trim().split(/\s+/);
+  const truncated = tokens.length > maxTokens;
+  return {
+    text: tokens.slice(0, maxTokens).join(' '),
+    truncated,
+  };
+}
+
 export async function generateImage(
   prompt: string,
   genres: string[] = [],
   timeoutMs: number = Number(process.env.NEXT_PUBLIC_IMAGE_TIMEOUT) || 15000
-): Promise<string | null> {
+): Promise<{ url: string | null; truncated: boolean }> {
+  const { text: truncatedPrompt, truncated } = truncatePrompt(prompt);
   const genrePrompt = genres.length > 0 ? `\nGéneros: ${genres.join(', ')}` : '';
-  const finalPrompt = `${prompt}${genrePrompt}\n\nEstilo: tinta minimalista, fondo blanco, el dibujo tiene que interpretar la historia relatada en el prompt`;
+  const finalPrompt = `${truncatedPrompt}${genrePrompt}\n\nEstilo: tinta minimalista, fondo blanco, el dibujo tiene que interpretar la historia relatada en el prompt`;
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -54,10 +67,10 @@ export async function generateImage(
         : undefined);
 
     if (!url) throw new Error('Image URL not found in response');
-    return url;
+    return { url, truncated };
   } catch (error: any) {
     if (error.name === 'AbortError') {
-      return null; // Aborted by timeout
+      return { url: null, truncated }; // Aborted by timeout
     }
     throw error;
   } finally {


### PR DESCRIPTION
## Summary
- add `truncatePrompt` to limit prompts to 77 tokens
- apply prompt truncation in `generateImage` and return flag when truncation occurs
- handle truncation info in `Story` component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(stalled: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a38f0a4c38832981210d2aeabaff49