### PR TITLE
docs: note CLIP token limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ You can also define `NEXT_PUBLIC_IMAGE_TIMEOUT` (in milliseconds) to control how
 
 Next.js will load variables from `.env.local` in development. For deployments, configure these environment variables through your hosting provider.
 
+## Límite de tokens de CLIP
+
+CLIP admite un máximo de 77 tokens por prompt. Si el texto supera este límite, será truncado y parte del mensaje se perderá.
+
+Para mantenerte dentro del límite:
+
+- Resume tus ideas y concéntrate en lo esencial.
+- Usa frases cortas y claras.
+- Evita palabras de relleno o redundantes.
+
 ## Cargar la PWA en React Native/Expo
 
 Para empaquetar esta PWA dentro de una app móvil:


### PR DESCRIPTION
## Summary
- document CLIP's 77-token limit and tips for concise prompts in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a38f0db9b883298c446c63d8b440c7