### PR TITLE
feat: add story generation types

### DIFF
--- a/types/story.ts
+++ b/types/story.ts
@@ -1,0 +1,42 @@
+export type Genero =
+  | 'Aventura'
+  | 'Ciencia ficción'
+  | 'Terror'
+  | 'Fantasía'
+  | 'Misterio'
+  | 'Romance'
+  | 'Comedia';
+
+export interface Estilo {
+  /** Estilo narrativo opcional */
+  narrativo?: 'serio' | 'cómico' | 'dramático' | 'infantil';
+  /** Estilo visual opcional para las ilustraciones */
+  visual?:
+    | 'tinta_minimalista'
+    | 'realista'
+    | 'acuarela'
+    | 'pixel_art'
+    | 'cómic';
+}
+
+export interface Ajustes {
+  /** Número de opciones que se generan por decisión */
+  opcionesPorDecision: number;
+  /** Modalidad de finalización de la historia */
+  final: 'capitulos' | 'final_sorpresa' | 'sin_final_definido' | 'infinita';
+  /** Número de capítulos, requerido en algunas modalidades */
+  capitulos?: number;
+}
+
+export interface ConfigGeneracion {
+  /** Prompt inicial de la historia */
+  prompt: string;
+  /** Géneros seleccionados */
+  generos: Genero[];
+  /** Estilo opcional de la narración e ilustraciones */
+  estilo?: Estilo;
+  /** Ajustes de generación de la historia */
+  ajustes?: Ajustes;
+}
+
+export type { Genero as Género, Estilo as EstiloHistoria, Ajustes as AjustesGeneracion, ConfigGeneracion as ConfiguracionGeneracion };


### PR DESCRIPTION
## Summary
- define `Genero` union of available story genres
- add `Estilo`, `Ajustes`, and `ConfigGeneracion` interfaces for story generation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next lint requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cc6d21548329b432803206347c2b