### PR TITLE
feat: add advanced story configuration drawer

### DIFF
--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -38,7 +38,31 @@ function countTokens(text: string) {
     .filter(Boolean).length;
 }
 
-const defaults: ConfigGeneracion = { estilo: {}, ajustes: {} };
+const defaults: ConfigGeneracion = {
+  generos: [],
+  estilo: {
+    tono: [],
+    ritmo: [],
+    voz: [],
+    tiempo: [],
+    formato: [],
+    descripcion: [],
+    dialogo: [],
+    matiz: [],
+  },
+  ajustes: {
+    publico: [],
+    epoca: [],
+    ambito: [],
+    estructura: [],
+    incluir: [],
+    evitar: [],
+    clasificacion: [],
+    idioma: [],
+    registro: [],
+    opcionesPorCapitulo: [],
+  },
+};
 
 export default function StoryForm() {
   const [prompt, setPrompt] = useState('');
@@ -55,7 +79,6 @@ export default function StoryForm() {
     endingMode: EndingMode;
     chaptersCount?: number;
   } | null>(null);
-  const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
   const [promptTruncated, setPromptTruncated] = useState(false);
   const [config, setConfig] = useState<ConfigGeneracion>(defaults);
   const [open, setOpen] = useState(false);
@@ -64,12 +87,19 @@ export default function StoryForm() {
     modality === 'capitulos' || modality === 'final_sorpresa';
 
   const toggleGenre = (genre: string) => {
-    setSelectedGenres((prev) =>
-      prev.includes(genre) ? prev.filter((g) => g !== genre) : [...prev, genre],
-    );
+    setConfig((prev) => ({
+      ...prev,
+      generos: prev.generos.includes(genre)
+        ? prev.generos.filter((g) => g !== genre)
+        : [...prev.generos, genre],
+    }));
   };
 
-  const clearGenres = () => setSelectedGenres([]);
+  const clearGenres = () =>
+    setConfig((prev) => ({
+      ...prev,
+      generos: [],
+    }));
 
   const handleSubmit = async () => {
     setLoading(true);
@@ -97,7 +127,7 @@ export default function StoryForm() {
         prompt,
         opciones_por_decision: Number(numOptions),
         final,
-        generos: selectedGenres,
+        generos: config.generos,
         estilo: config.estilo,
         ajustes: config.ajustes,
         ...((final === 'capitulos' || final === 'final_sorpresa') && chapters
@@ -124,7 +154,7 @@ export default function StoryForm() {
             story: prompt,
             option: '',
             optionsPerDecision: Number(numOptions),
-            generos: selectedGenres,
+            generos: config.generos,
             estilo: config.estilo,
             ajustes: config.ajustes,
           }),
@@ -234,34 +264,13 @@ export default function StoryForm() {
           >
             Configuración
           </button>
-          <div className="flex flex-wrap gap-2 max-w-xl">
-            {config.estilo.tono && (
-              <span className="px-2 py-1 text-sm rounded-full bg-accent text-black">
-                {config.estilo.tono}
-              </span>
-            )}
-            {config.estilo.voz && (
-              <span className="px-2 py-1 text-sm rounded-full bg-accent text-black">
-                {config.estilo.voz}
-              </span>
-            )}
-            {config.estilo.epoca && (
-              <span className="px-2 py-1 text-sm rounded-full bg-accent text-black">
-                {config.estilo.epoca}
-              </span>
-            )}
-            {config.ajustes.longitud && (
-              <span className="px-2 py-1 text-sm rounded-full bg-accent text-black">
-                {config.ajustes.longitud}
-              </span>
-            )}
-          </div>
+          <div className="flex flex-wrap gap-2 max-w-xl" />
           <div className="flex flex-col gap-2 p-4 border border-black/30 rounded-lg max-w-xl w-full">
             {GENRES.map((genre) => (
               <label key={genre} className="flex items-center gap-2">
                 <input
                   type="checkbox"
-                  checked={selectedGenres.includes(genre)}
+                  checked={config.generos.includes(genre)}
                   onChange={() => toggleGenre(genre)}
                 />
                 {genre}
@@ -275,9 +284,9 @@ export default function StoryForm() {
               Limpiar
             </button>
           </div>
-          {selectedGenres.length > 0 && (
+          {config.generos.length > 0 && (
             <div className="flex flex-wrap gap-2 max-w-xl">
-              {selectedGenres.map((genre) => (
+              {config.generos.map((genre) => (
                 <span
                   key={genre}
                   className="px-2 py-1 text-sm rounded-full bg-accent text-black"
@@ -303,7 +312,7 @@ export default function StoryForm() {
           optionsPerDecision={storyConfig.optionsPerDecision}
           endingMode={storyConfig.endingMode}
           chaptersCount={storyConfig.chaptersCount}
-          genres={selectedGenres}
+          genres={config.generos}
         />
       )}
       {promptTruncated && (

--- a/app/components/StorySettings.tsx
+++ b/app/components/StorySettings.tsx
@@ -2,15 +2,43 @@
 
 import { useEffect, useState } from 'react';
 
+export interface Estilo {
+  tono: string[];
+  ritmo: string[];
+  voz: string[];
+  tiempo: string[];
+  formato: string[];
+  descripcion: string[];
+  dialogo: string[];
+  matiz: string[];
+}
+
+export interface Ajustes {
+  publico: string[];
+  epoca: string[];
+  ambito: string[];
+  lugar?: string;
+  longitudPalabras?: number;
+  estructura: string[];
+  incluir?: string[];
+  evitar?: string[];
+  clasificacion: string[];
+  idioma: string[];
+  registro: string[];
+  creatividad?: number;
+  topP?: number;
+  semilla?: number;
+  opcionesPorCapitulo: string[];
+  consistenciaSaga?: boolean;
+  estiloVisual?: string;
+  paleta?: string;
+}
+
 export interface ConfigGeneracion {
-  estilo: {
-    tono?: string;
-    voz?: string;
-    epoca?: string;
-  };
-  ajustes: {
-    longitud?: string;
-  };
+  generos: string[];
+  estilo: Estilo;
+  ajustes: Ajustes;
+}
 
 interface StorySettingsProps {
   open: boolean;
@@ -19,8 +47,73 @@ interface StorySettingsProps {
   onSave: (cfg: ConfigGeneracion) => void;
 }
 
-export default function StorySettings({ open, config, onClose, onSave }: StorySettingsProps) {
+const TONOS = [
+  'ligero',
+  'oscuro',
+  'melancólico',
+  'esperanzador',
+  'satírico',
+  'absurdo',
+];
+const RITMOS = ['rápido', 'medio', 'pausado'];
+const VOCES = [
+  '1ª persona',
+  '2ª persona',
+  '3ª limitada',
+  '3ª omnisciente',
+  'narrador no fiable',
+];
+const TIEMPOS = ['pasado', 'presente'];
+const FORMATOS = [
+  'relato clásico',
+  'microcuento',
+  'epistolar',
+  'diario',
+  'guion cinematográfico',
+  'monólogo interior',
+  'elige tu aventura',
+];
+const DENSIDADES = ['baja', 'media', 'alta'];
+const DIALOGO = ['poco', 'equilibrado', 'mucho'];
+const MATICES = [
+  'poético',
+  'minimalista',
+  'pulp/noir',
+  'realismo mágico',
+  'cyberpunk',
+  'slice-of-life',
+  'humorístico',
+];
+
+const PUBLICO = ['infantil', 'middle-grade', 'juvenil', 'adulto'];
+const EPOCAS = [
+  'prehistoria',
+  'medieval',
+  'victoriana',
+  'contemporánea',
+  'futurista',
+];
+const AMBITOS = ['urbano', 'rural'];
+const ESTRUCTURAS = [
+  '3 actos',
+  'en media res',
+  'viaje del héroe',
+  'con cliffhanger final',
+];
+const CLASIFICACION = ['PG', '+13', '+16'];
+const IDIOMAS = ['es-AR', 'es-MX', 'neutral'];
+const REGISTROS = ['formal', 'informal'];
+const OPCIONES_POR_CAPITULO = ['2', '3', '4'];
+
+export default function StorySettings({
+  open,
+  config,
+  onClose,
+  onSave,
+}: StorySettingsProps) {
   const [local, setLocal] = useState<ConfigGeneracion>(config);
+  const [incluirInput, setIncluirInput] = useState('');
+  const [evitarInput, setEvitarInput] = useState('');
 
   useEffect(() => {
     if (open) setLocal(config);
@@ -28,16 +121,56 @@ export default function StorySettings({ open, config, onClose, onSave }: StorySe
 
   if (!open) return null;
 
-  const handleChange = (
+  const toggleItem = (
     section: 'estilo' | 'ajustes',
     key: string,
     value: string,
   ) => {
+    setLocal((prev) => {
+      const prevSection = prev[section] as Record<string, string[] | undefined>;
+      const current = prevSection[key] || [];
+      const exists = current.includes(value);
+      return {
+        ...prev,
+        [section]: {
+          ...prevSection,
+          [key]: exists ? current.filter((v) => v !== value) : [...current, value],
+        },
+      } as ConfigGeneracion;
+    });
+  };
+
+  const handleField = (
+    key: keyof Ajustes,
+    value: string | number | boolean,
+  ) => {
     setLocal((prev) => ({
       ...prev,
-      [section]: {
-        ...(prev[section] as Record<string, string | undefined>),
+      ajustes: {
+        ...prev.ajustes,
         [key]: value,
+      },
+    }));
+  };
+
+  const addTag = (key: 'incluir' | 'evitar', value: string) => {
+    const v = value.trim();
+    if (!v) return;
+    setLocal((prev) => ({
+      ...prev,
+      ajustes: {
+        ...prev.ajustes,
+        [key]: [...(prev.ajustes[key] || []), v],
+      },
+    }));
+  };
+
+  const removeTag = (key: 'incluir' | 'evitar', value: string) => {
+    setLocal((prev) => ({
+      ...prev,
+      ajustes: {
+        ...prev.ajustes,
+        [key]: (prev.ajustes[key] || []).filter((t) => t !== value),
       },
     }));
   };
@@ -47,37 +180,227 @@ export default function StorySettings({ open, config, onClose, onSave }: StorySe
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
-      <div className="bg-white p-4 rounded-lg space-y-2 w-full max-w-sm">
-        <input
-          type="text"
-          placeholder="Tono"
-          value={local.estilo.tono ?? ''}
-          onChange={(e) => handleChange('estilo', 'tono', e.target.value)}
-          className="w-full p-1 border border-black/30 rounded"
-        />
-        <input
-          type="text"
-          placeholder="Voz"
-          value={local.estilo.voz ?? ''}
-          onChange={(e) => handleChange('estilo', 'voz', e.target.value)}
-          className="w-full p-1 border border-black/30 rounded"
-        />
-        <input
-          type="text"
-          placeholder="Época"
-          value={local.estilo.epoca ?? ''}
-          onChange={(e) => handleChange('estilo', 'epoca', e.target.value)}
-          className="w-full p-1 border border-black/30 rounded"
-        />
-        <input
-          type="text"
-          placeholder="Longitud"
-          value={local.ajustes.longitud ?? ''}
-          onChange={(e) => handleChange('ajustes', 'longitud', e.target.value)}
-          className="w-full p-1 border border-black/30 rounded"
-        />
-        <div className="flex justify-end gap-2 pt-2">
+    <div className="fixed inset-0 flex justify-end">
+      <div
+        className="fixed inset-0 bg-black/50"
+        onClick={onClose}
+        aria-hidden
+      />
+      <div className="relative w-80 sm:w-96 h-full bg-white p-4 overflow-y-auto">
+        <h2 className="text-lg font-bold mb-2">Estilos (literarios)</h2>
+        {[
+          { key: 'tono', label: 'Tono', options: TONOS },
+          { key: 'ritmo', label: 'Ritmo/Pacing', options: RITMOS },
+          { key: 'voz', label: 'Voz/Punto de vista', options: VOCES },
+          { key: 'tiempo', label: 'Tiempo verbal', options: TIEMPOS },
+          { key: 'formato', label: 'Formato', options: FORMATOS },
+          { key: 'descripcion', label: 'Densidad descriptiva', options: DENSIDADES },
+          { key: 'dialogo', label: 'Diálogo vs. narración', options: DIALOGO },
+          { key: 'matiz', label: 'Matiz estilístico', options: MATICES },
+        ].map(({ key, label, options }) => (
+          <div key={key} className="mb-4">
+            <p className="font-semibold">{label}</p>
+            {options.map((opt) => (
+              <label key={opt} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={(local.estilo[key as keyof Estilo] || []).includes(opt)}
+                  onChange={() => toggleItem('estilo', key, opt)}
+                />
+                {opt}
+              </label>
+            ))}
+          </div>
+        ))}
+
+        <h2 className="text-lg font-bold mb-2">Ajustes extra</h2>
+        {[
+          { key: 'publico', label: 'Público objetivo', options: PUBLICO },
+          { key: 'epoca', label: 'Época', options: EPOCAS },
+          { key: 'ambito', label: 'Ámbito', options: AMBITOS },
+          { key: 'estructura', label: 'Estructura', options: ESTRUCTURAS },
+          { key: 'clasificacion', label: 'Clasificación', options: CLASIFICACION },
+          { key: 'idioma', label: 'Idioma', options: IDIOMAS },
+          { key: 'registro', label: 'Registro', options: REGISTROS },
+          {
+            key: 'opcionesPorCapitulo',
+            label: 'Interactividad: opciones por capítulo',
+            options: OPCIONES_POR_CAPITULO,
+          },
+        ].map(({ key, label, options }) => (
+          <div key={key} className="mb-4">
+            <p className="font-semibold">{label}</p>
+            {options.map((opt) => (
+              <label key={opt} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={(local.ajustes[key as keyof Ajustes] as string[] | undefined)?.includes(opt)}
+                  onChange={() => toggleItem('ajustes', key, opt)}
+                />
+                {opt}
+              </label>
+            ))}
+          </div>
+        ))}
+
+        <div className="mb-4">
+          <p className="font-semibold">País/Ciudad</p>
+          <input
+            type="text"
+            value={local.ajustes.lugar || ''}
+            onChange={(e) => handleField('lugar', e.target.value)}
+            className="w-full p-1 border border-black/30 rounded"
+          />
+        </div>
+
+        <div className="mb-4">
+          <p className="font-semibold">Longitud objetivo (palabras)</p>
+          <input
+            type="number"
+            value={local.ajustes.longitudPalabras ?? ''}
+            onChange={(e) => handleField('longitudPalabras', Number(e.target.value))}
+            className="w-full p-1 border border-black/30 rounded"
+          />
+        </div>
+
+        <div className="mb-4">
+          <p className="font-semibold">Temas/elementos obligatorios</p>
+          <div className="flex flex-wrap gap-2 mb-2">
+            {local.ajustes.incluir?.map((tag) => (
+              <span
+                key={tag}
+                className="px-2 py-1 bg-accent rounded-full text-sm flex items-center gap-1"
+              >
+                {tag}
+                <button
+                  type="button"
+                  onClick={() => removeTag('incluir', tag)}
+                  className="text-black"
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+          <input
+            type="text"
+            value={incluirInput}
+            onChange={(e) => setIncluirInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                addTag('incluir', incluirInput);
+                setIncluirInput('');
+                e.preventDefault();
+              }
+            }}
+            className="w-full p-1 border border-black/30 rounded"
+          />
+        </div>
+
+        <div className="mb-4">
+          <p className="font-semibold">Evitar temas</p>
+          <div className="flex flex-wrap gap-2 mb-2">
+            {local.ajustes.evitar?.map((tag) => (
+              <span
+                key={tag}
+                className="px-2 py-1 bg-accent rounded-full text-sm flex items-center gap-1"
+              >
+                {tag}
+                <button
+                  type="button"
+                  onClick={() => removeTag('evitar', tag)}
+                  className="text-black"
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+          <input
+            type="text"
+            value={evitarInput}
+            onChange={(e) => setEvitarInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                addTag('evitar', evitarInput);
+                setEvitarInput('');
+                e.preventDefault();
+              }
+            }}
+            className="w-full p-1 border border-black/30 rounded"
+          />
+        </div>
+
+        <div className="mb-4">
+          <p className="font-semibold">Creatividad</p>
+          <input
+            type="range"
+            min={0.1}
+            max={1}
+            step={0.1}
+            value={local.ajustes.creatividad ?? 0.7}
+            onChange={(e) => handleField('creatividad', parseFloat(e.target.value))}
+            className="w-full"
+          />
+          <span>{(local.ajustes.creatividad ?? 0.7).toFixed(1)}</span>
+        </div>
+
+        <div className="mb-4">
+          <p className="font-semibold">top_p</p>
+          <input
+            type="range"
+            min={0.1}
+            max={1}
+            step={0.1}
+            value={local.ajustes.topP ?? 0.7}
+            onChange={(e) => handleField('topP', parseFloat(e.target.value))}
+            className="w-full"
+          />
+          <span>{(local.ajustes.topP ?? 0.7).toFixed(1)}</span>
+        </div>
+
+        <div className="mb-4">
+          <p className="font-semibold">Semilla aleatoria</p>
+          <input
+            type="number"
+            value={local.ajustes.semilla ?? ''}
+            onChange={(e) => handleField('semilla', Number(e.target.value))}
+            className="w-full p-1 border border-black/30 rounded"
+          />
+        </div>
+
+        <div className="mb-4">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={local.ajustes.consistenciaSaga || false}
+              onChange={(e) => handleField('consistenciaSaga', e.target.checked)}
+            />
+            Consistencia de mundo (sagas)
+          </label>
+        </div>
+
+        <div className="mb-4">
+          <p className="font-semibold">Estilo visual</p>
+          <input
+            type="text"
+            value={local.ajustes.estiloVisual || ''}
+            onChange={(e) => handleField('estiloVisual', e.target.value)}
+            className="w-full p-1 border border-black/30 rounded"
+          />
+        </div>
+
+        <div className="mb-6">
+          <p className="font-semibold">Paleta</p>
+          <input
+            type="text"
+            value={local.ajustes.paleta || ''}
+            onChange={(e) => handleField('paleta', e.target.value)}
+            className="w-full p-1 border border-black/30 rounded"
+          />
+        </div>
+
+        <div className="flex justify-end gap-2 pb-4">
           <button
             type="button"
             onClick={onClose}

--- a/types/story.ts
+++ b/types/story.ts
@@ -8,35 +8,41 @@ export type Genero =
   | 'Comedia';
 
 export interface Estilo {
-  /** Estilo narrativo opcional */
-  narrativo?: 'serio' | 'cómico' | 'dramático' | 'infantil';
-  /** Estilo visual opcional para las ilustraciones */
-  visual?:
-    | 'tinta_minimalista'
-    | 'realista'
-    | 'acuarela'
-    | 'pixel_art'
-    | 'cómic';
+  tono: string[];
+  ritmo: string[];
+  voz: string[];
+  tiempo: string[];
+  formato: string[];
+  descripcion: string[];
+  dialogo: string[];
+  matiz: string[];
 }
 
 export interface Ajustes {
-  /** Número de opciones que se generan por decisión */
-  opcionesPorDecision: number;
-  /** Modalidad de finalización de la historia */
-  final: 'capitulos' | 'final_sorpresa' | 'sin_final_definido' | 'infinita';
-  /** Número de capítulos, requerido en algunas modalidades */
-  capitulos?: number;
+  publico: string[];
+  epoca: string[];
+  ambito: string[];
+  lugar?: string;
+  longitudPalabras?: number;
+  estructura: string[];
+  incluir?: string[];
+  evitar?: string[];
+  clasificacion: string[];
+  idioma: string[];
+  registro: string[];
+  creatividad?: number;
+  topP?: number;
+  semilla?: number;
+  opcionesPorCapitulo: string[];
+  consistenciaSaga?: boolean;
+  estiloVisual?: string;
+  paleta?: string;
 }
 
 export interface ConfigGeneracion {
-  /** Prompt inicial de la historia */
-  prompt: string;
-  /** Géneros seleccionados */
   generos: Genero[];
-  /** Estilo opcional de la narración e ilustraciones */
-  estilo?: Estilo;
-  /** Ajustes de generación de la historia */
-  ajustes?: Ajustes;
+  estilo: Estilo;
+  ajustes: Ajustes;
 }
 
 export type { Genero as Género, Estilo as EstiloHistoria, Ajustes as AjustesGeneracion, ConfigGeneracion as ConfiguracionGeneracion };


### PR DESCRIPTION
## Summary
- replace simple settings modal with right-side drawer for advanced story configuration
- support detailed literary style and extra adjustments, storing selections in structured arrays
- centralize genre selection within config object and update type definitions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d1e56e208329b5e6838ddd5e8771