### PR TITLE
Add back-navigation handling in Story components

### DIFF
--- a/app/components/Story.tsx
+++ b/app/components/Story.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { generateImage } from '@/lib/imageGenerator';
 
 interface StoryProps {
@@ -17,6 +16,8 @@ interface StoryProps {
   chaptersCount?: number;
   /** Géneros seleccionados para la historia */
   genres: string[];
+  /** Acción a ejecutar al volver al formulario inicial */
+  onBack: () => void;
 }
 
 interface Chapter {
@@ -43,6 +44,7 @@ export default function Story({
   endingMode,
   chaptersCount,
   genres,
+  onBack,
 }: StoryProps) {
   const [chapters, setChapters] = useState<Chapter[]>([
     { texto: initialStory, imageUrl: null },
@@ -54,7 +56,6 @@ export default function Story({
   const [loading, setLoading] = useState(false);
   const [currentChapter, setCurrentChapter] = useState(1);
   const [history, setHistory] = useState<HistoryEntry[]>([]);
-  const router = useRouter();
 
   const handleSpeak = (text: string) => {
     const utterance = new SpeechSynthesisUtterance(text);
@@ -151,7 +152,7 @@ export default function Story({
     setOptions(initialOptions.slice(0, optionsPerDecision));
     setCurrentChapter(1);
     setHistory([]);
-    router.push('/');
+    onBack();
   };
 
   return (

--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -83,6 +83,12 @@ export default function StoryForm() {
   const [config, setConfig] = useState<ConfigGeneracion>(defaults);
   const [open, setOpen] = useState(false);
 
+  const resetStory = () => {
+    setInitialStory(null);
+    setInitialOptions([]);
+    setStoryConfig(null);
+  };
+
   const showChapters =
     modality === 'capitulos' || modality === 'final_sorpresa';
 
@@ -313,6 +319,7 @@ export default function StoryForm() {
           endingMode={storyConfig.endingMode}
           chaptersCount={storyConfig.chaptersCount}
           genres={config.generos}
+          onBack={resetStory}
         />
       )}
       {promptTruncated && (


### PR DESCRIPTION
## Summary
- allow Story component to accept `onBack` callback instead of router navigation
- reset StoryForm state via new `resetStory` function and pass as `onBack`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx jest` *(fails: npm error canceled)*
- `npm run lint` *(fails: interactive question about ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d88120888329843fa4362e2fe43d