### PR TITLE
Use 'genres' field in story API requests

### DIFF
--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -156,7 +156,7 @@ export default function StoryForm() {
         prompt,
         opciones_por_decision: Number(numOptions),
         final,
-        generos: config.generos,
+        genres: config.generos,
         estilo: config.estilo,
         ajustes: config.ajustes,
         ...((final === 'capitulos' || final === 'final_sorpresa') && chapters
@@ -183,7 +183,7 @@ export default function StoryForm() {
             story: prompt,
             option: '',
             optionsPerDecision: Number(numOptions),
-            generos: config.generos,
+            genres: config.generos,
             estilo: config.estilo,
             ajustes: config.ajustes,
           }),


### PR DESCRIPTION
## Summary
- map `config.generos` to `genres` when creating stories
- send `genres` to `/api/story`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a3eae43ccc8329bc4cef38d36dc543