### PR TITLE
feat: add story style and settings options

### DIFF
--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -10,32 +10,64 @@ export async function POST(req: Request) {
   }
 
   try {
-    const { story, option, optionsPerDecision, genres } = await req.json();
+    const {
+      story,
+      option,
+      optionsPerDecision,
+      genres,
+      estilo = {},
+      ajustes = {},
+    } = await req.json();
 
     const genreLine =
       Array.isArray(genres) && genres.length > 0
         ? `Géneros a respetar: ${genres.join(', ')}.`
         : '';
 
+    const formatSection = (
+      title: string,
+      data: Record<string, unknown>
+    ): string => {
+      const entries = Object.entries(data)
+        .filter(([, v]) =>
+          Array.isArray(v) ? (v as unknown[]).length > 0 : v !== undefined
+        )
+        .map(([k, v]) => {
+          const key = k.replace(/([A-Z])/g, ' $1').toLowerCase();
+          const value = Array.isArray(v) ? (v as unknown[]).join(', ') : v;
+          return `${key}: ${value}`;
+        });
+      return entries.length > 0 ? `${title}: ${entries.join('; ')}.` : '';
+    };
+
+    const estiloLine = formatSection('Estilo', estilo);
+    const ajustesLine = formatSection('Ajustes', ajustes);
+
     const systemPrompt = [
       "Eres un generador de historias ramificadas. Responde con el siguiente capítulo seguido de las opciones solicitadas, cada una en una línea.",
       genreLine,
+      estiloLine,
+      ajustesLine,
     ]
       .filter(Boolean)
       .join("\n\n");
 
+    const messages = [
+      {
+        role: "system" as const,
+        content: systemPrompt,
+      },
+      {
+        role: "user" as const,
+        content: `${story}\n\nOpción elegida: ${option}\n\nGenera ${optionsPerDecision} opciones para continuar la historia.`,
+      },
+    ];
+
+    console.log('Mensajes enviados a Groq:', messages);
+
     const completion = await createChatCompletion({
       model: "openai/gpt-oss-120b",
-      messages: [
-        {
-          role: "system",
-          content: systemPrompt,
-        },
-        {
-          role: "user",
-          content: `${story}\n\nOpción elegida: ${option}\n\nGenera ${optionsPerDecision} opciones para continuar la historia.`,
-        },
-      ],
+      messages,
     });
 
     const text =

--- a/app/components/Story.tsx
+++ b/app/components/Story.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { generateImage } from '@/lib/imageGenerator';
+import type { Estilo, Ajustes } from '@/types/story';
 //import { useRouter } from 'next/router';
 
 interface StoryProps {
@@ -17,6 +18,10 @@ interface StoryProps {
   chaptersCount?: number;
   /** Géneros seleccionados para la historia */
   genres: string[];
+  /** Estilo deseado para la historia */
+  estilo: Estilo;
+  /** Ajustes adicionales de generación */
+  ajustes: Ajustes;
   /** Acción a ejecutar al volver al formulario inicial */
   onBack: () => void;
 }
@@ -45,6 +50,8 @@ export default function Story({
   endingMode,
   chaptersCount,
   genres,
+  estilo,
+  ajustes,
   onBack,
 }: StoryProps) {
   const [chapters, setChapters] = useState<Chapter[]>([
@@ -98,7 +105,14 @@ export default function Story({
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ story: nextStory, option, optionsPerDecision, genres }),
+        body: JSON.stringify({
+          story: nextStory,
+          option,
+          optionsPerDecision,
+          genres,
+          estilo,
+          ajustes,
+        }),
       });
       const data = await response.json();
       const text = data.text || '';

--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -375,6 +375,8 @@ export default function StoryForm() {
           endingMode={storyConfig.endingMode}
           chaptersCount={storyConfig.chaptersCount}
           genres={config.generos}
+          estilo={config.estilo}
+          ajustes={config.ajustes}
           onBack={resetStory}
         />
       )}


### PR DESCRIPTION
## Summary
- allow API route to receive `estilo` and `ajustes`
- send `estilo` and `ajustes` from Story component and form
- log Groq messages for manual verification

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt, aborted)*
- `npx ts-node -r tsconfig-paths/register -O '{"module":"commonjs"}' -e "process.env.GROQ_API_KEY='test'; const { POST } = require('./app/api/story/route'); (async () => {const req = new Request('http://localhost',{method:'POST',body: JSON.stringify({story:'Inicio', option:'Opción A', optionsPerDecision:2, genres:['Aventura'], estilo:{tono:['oscuro']}, ajustes:{publico:['adulto']}})}); try{await POST(req);} catch(e){}})();"`

------
https://chatgpt.com/codex/tasks/task_e_68a3eae68a98832985098595a7f0f79f