### PR TITLE
Display previous choices before story chapters

### DIFF
--- a/app/components/Story.tsx
+++ b/app/components/Story.tsx
@@ -183,6 +183,9 @@ export default function Story({
     <div className="space-y-4">
       {chapters.map(({ texto, imageUrl }, idx) => (
         <div key={idx} className="space-y-4">
+          {idx > 0 && (
+            <p className="whitespace-pre-line">&gt; {choices[idx - 1]}</p>
+          )}
           <p className="whitespace-pre-line">{texto}</p>
           <button
             onClick={() => handleSpeak(texto)}


### PR DESCRIPTION
## Summary
- show user's last choice before rendering each subsequent chapter

## Testing
- `npx jest`
- `npm run lint` *(interactive prompt blocked; no results)*
- `npm run dev` *(manual inspection)*

------
https://chatgpt.com/codex/tasks/task_e_68a47e67467c83298781c4e00784552e