### PR TITLE
Add creative mode selector for story generation

### DIFF
--- a/app/api/options/route.ts
+++ b/app/api/options/route.ts
@@ -4,7 +4,7 @@ const MAX_OPTIONS = 5;
 
 export async function POST(req: Request) {
   try {
-    const { prompt, numOptions } = await req.json();
+    const { prompt, numOptions, temperature, top_p } = await req.json();
 
     const count = Number(numOptions) || 1;
     if (count > MAX_OPTIONS) {
@@ -20,6 +20,8 @@ export async function POST(req: Request) {
           model: "openai/gpt-oss-120b",
           messages: [{ role: "user", content: prompt }],
           n: 1,
+          temperature,
+          top_p,
         })
       )
     );

--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -70,9 +70,16 @@ export async function POST(req: Request) {
 
     console.log('Mensajes enviados a Groq:', messages);
 
+    const { temperature, top_p } = ajustes as {
+      temperature?: number;
+      top_p?: number;
+    };
+
     const completion = await createChatCompletion({
       model: "openai/gpt-oss-120b",//"moonshotai/kimi-k2-instruct",//"deepseek-r1-distill-llama-70b",//"openai/gpt-oss-120b",
       messages,
+      temperature,
+      top_p,
     });
 
     const text =

--- a/app/components/Story.tsx
+++ b/app/components/Story.tsx
@@ -100,6 +100,12 @@ export default function Story({
 
     try {
       const nextChapter = currentChapter + 1;
+      const { creatividad, topP, ...restAjustes } = ajustes;
+      const ajustesPayload = {
+        ...restAjustes,
+        temperature: creatividad,
+        top_p: topP,
+      };
       const response = await fetch('/api/story', {
         method: 'POST',
         headers: {
@@ -111,7 +117,7 @@ export default function Story({
           optionsPerDecision,
           genres,
           estilo,
-          ajustes,
+          ajustes: ajustesPayload,
         }),
       });
       const data = await response.json();

--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -151,13 +151,18 @@ export default function StoryForm() {
         }
       })();
 
+      const ajustesPayload = (() => {
+        const { creatividad, topP, ...rest } = config.ajustes;
+        return { ...rest, temperature: creatividad, top_p: topP };
+      })();
+
       const payload: Record<string, unknown> = {
         prompt,
         opciones_por_decision: Number(numOptions),
         final,
         genres: config.generos,
         estilo: config.estilo,
-        ajustes: config.ajustes,
+        ajustes: ajustesPayload,
         ...((final === 'capitulos' || final === 'final_sorpresa') && chapters
           ? { capitulos: Number(chapters) }
           : {}),
@@ -184,7 +189,7 @@ export default function StoryForm() {
             optionsPerDecision: Number(numOptions),
             genres: config.generos,
             estilo: config.estilo,
-            ajustes: config.ajustes,
+            ajustes: ajustesPayload,
           }),
         });
         const storyData = await storyRes.json().catch(() => ({}));

--- a/app/components/StorySettings.tsx
+++ b/app/components/StorySettings.tsx
@@ -86,6 +86,14 @@ const IDIOMAS = ['es-AR', 'es-MX', 'neutral'];
 const REGISTROS = ['formal', 'informal'];
 const OPCIONES_POR_CAPITULO = ['2', '3', '4'];
 
+type CreativeMode = 'classic' | 'creative' | 'crazy';
+
+const CREATIVE_MODES: Record<CreativeMode, { label: string; temperature: number; topP: number }> = {
+  classic: { label: 'Modo clásico', temperature: 0.7, topP: 0.7 },
+  creative: { label: 'Modo creativo', temperature: 0.9, topP: 0.9 },
+  crazy: { label: 'Modo loco', temperature: 1, topP: 1 },
+};
+
 /** Config de secciones fuertemente tipadas */
 export const ESTILO_SECTIONS: { key: keyof Estilo; label: string; options: string[] }[] = [
   { key: 'tono', label: 'Tono', options: TONOS },
@@ -117,6 +125,21 @@ export default function StorySettings({ open, config, onClose, onSave }: StorySe
   useEffect(() => {
     if (open) setLocal(config);
   }, [open, config]);
+
+  const currentMode: CreativeMode =
+    (Object.keys(CREATIVE_MODES) as CreativeMode[]).find(
+      m =>
+        CREATIVE_MODES[m].temperature === (local.ajustes.creatividad ?? 0.7) &&
+        CREATIVE_MODES[m].topP === (local.ajustes.topP ?? 0.7)
+    ) ?? 'classic';
+
+  const setCreativeMode = (mode: CreativeMode) => {
+    const cfg = CREATIVE_MODES[mode];
+    setLocal(prev => ({
+      ...prev,
+      ajustes: { ...prev.ajustes, creatividad: cfg.temperature, topP: cfg.topP },
+    }));
+  };
 
   if (!open) return null;
 
@@ -303,34 +326,18 @@ export default function StorySettings({ open, config, onClose, onSave }: StorySe
         </div>
 
         <div className="mb-4">
-          <p className="font-semibold">Creatividad</p>
-          <input
-            type="range"
-            min={0.1}
-            max={1}
-            step={0.1}
-            value={local.ajustes.creatividad ?? 0.7}
-            onChange={e => handleField('creatividad', parseFloat(e.target.value))}
-            className="w-full"
-            title="Ajuste de creatividad"
-            placeholder="Ajuste de creatividad"
-          />
-          <span>{(local.ajustes.creatividad ?? 0.7).toFixed(1)}</span>
-        </div>
-
-        <div className="mb-4">
-          <p className="font-semibold">top_p</p>
-          <input
-            type="range"
-            min={0.1}
-            max={1}
-            step={0.1}
-            value={local.ajustes.topP ?? 0.7}
-            onChange={e => handleField('topP', parseFloat(e.target.value))}
-            className="w-full"
-            placeholder="range"
-          />
-          <span>{(local.ajustes.topP ?? 0.7).toFixed(1)}</span>
+          <p className="font-semibold">Modo de creatividad</p>
+          <select
+            value={currentMode}
+            onChange={e => setCreativeMode(e.target.value as CreativeMode)}
+            className="w-full p-1 border border-black/30 rounded"
+          >
+            {Object.entries(CREATIVE_MODES).map(([key, { label }]) => (
+              <option key={key} value={key}>
+                {label}
+              </option>
+            ))}
+          </select>
         </div>
 
         <div className="mb-4">


### PR DESCRIPTION
## Summary
- Add CreativeMode mapping and UI selector for classic, creative, and crazy modes
- Convert creativity settings to temperature/top_p values for API payloads
- Forward temperature and top_p to Groq in story and options routes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a503a333cc8329b6934639ddc8d9d9