### PR TITLE
feat: enable creative defaults

### DIFF
--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -68,6 +68,8 @@ const defaults: ConfigGeneracion = {
     clasificacion: [],
     idioma: [],
     registro: [],
+    creatividad: 0.9,
+    topP: 0.9,
     opcionesPorCapitulo: [],
   },
 };

--- a/app/components/StorySettings.tsx
+++ b/app/components/StorySettings.tsx
@@ -129,9 +129,11 @@ export default function StorySettings({ open, config, onClose, onSave }: StorySe
   const currentMode: CreativeMode =
     (Object.keys(CREATIVE_MODES) as CreativeMode[]).find(
       m =>
-        CREATIVE_MODES[m].temperature === (local.ajustes.creatividad ?? 0.7) &&
-        CREATIVE_MODES[m].topP === (local.ajustes.topP ?? 0.7)
-    ) ?? 'classic';
+        CREATIVE_MODES[m].temperature ===
+          (local.ajustes.creatividad ?? CREATIVE_MODES.creative.temperature) &&
+        CREATIVE_MODES[m].topP ===
+          (local.ajustes.topP ?? CREATIVE_MODES.creative.topP)
+    ) ?? 'creative';
 
   const setCreativeMode = (mode: CreativeMode) => {
     const cfg = CREATIVE_MODES[mode];


### PR DESCRIPTION
## Summary
- default story generation sessions to creative mode with higher temperature and topP
- adjust creative mode detection to use creative defaults when settings absent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a50969d15c8329995ef5c8374402df