### PR TITLE
Handle alternative option formats in story parser

### DIFF
--- a/__tests__/parseStoryResponse.test.ts
+++ b/__tests__/parseStoryResponse.test.ts
@@ -14,4 +14,25 @@ describe('parseStoryResponse', () => {
     expect(story).toBe('');
     expect(options).toEqual(['1. Explorar la cueva', '2. Regresar']);
   });
+
+  it('reconoce opciones con distintos formatos numerados', () => {
+    const text = 'Historia\n---\n1) Ir al bosque\n2- Ir al mar\n3: Ir a la ciudad';
+    const { story, options } = parseStoryResponse(text, 3);
+    expect(story).toBe('Historia');
+    expect(options).toEqual([
+      '1) Ir al bosque',
+      '2- Ir al mar',
+      '3: Ir a la ciudad',
+    ]);
+  });
+
+  it.each([
+    ['1) Explorar la cueva\n2) Regresar', ['1) Explorar la cueva', '2) Regresar']],
+    ['1- Explorar la cueva\n2- Regresar', ['1- Explorar la cueva', '2- Regresar']],
+    ['1: Explorar la cueva\n2: Regresar', ['1: Explorar la cueva', '2: Regresar']],
+  ])('maneja respuesta solo con opciones con formato alternativo', (text, expected) => {
+    const { story, options } = parseStoryResponse(text, 2);
+    expect(story).toBe('');
+    expect(options).toEqual(expected);
+  });
 });

--- a/lib/parseStoryResponse.ts
+++ b/lib/parseStoryResponse.ts
@@ -1,17 +1,17 @@
 export function parseStoryResponse(text: string, numOptions: number) {
-   console.log("📩 Texto completo recibido:", text);
-  const [storyPart, optionsPart] = text.includes('---')
-    ? text.split('---', 2)
-    : ['', text];
-     console.log("✂️ Parte historia:", storyPart.trim());
+  console.log("📩 Texto completo recibido:", text);
+  const [storyPart, optionsPartRaw] = text.split(/\n\s*---\s*\n/, 2);
+  const hasSeparator = optionsPartRaw !== undefined;
+  const story = hasSeparator ? storyPart.trim() : '';
+  const optionsPart = hasSeparator ? optionsPartRaw : text;
+  console.log("✂️ Parte historia:", story);
   console.log("✂️ Parte opciones (raw):", optionsPart);
-  const story = storyPart.trim();
   const options = optionsPart
     .split('\n')
     .map((l) => l.trim())
-    .filter((l) => /^\d+\./.test(l))
+    .filter((l) => /^\d+[\.\)\-:]/.test(l))
     .slice(0, numOptions);
-    
+
   console.log("✅ Opciones parseadas:", options);
   return { story, options };
 }


### PR DESCRIPTION
## Summary
- Improve story parser to split options using a dashed line delimiter
- Support option numbering like `1)`, `1-`, and `1:` in addition to `1.`
- Expand tests to cover alternate numbering formats and ensure options are extracted

## Testing
- `npx jest` *(fails: Failed to call `useTranslations` because the context from `NextIntlClientProvider` was not found)*
- `npx jest __tests__/parseStoryResponse.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a52fd29e208329a17aabc9886feee3