### PR TITLE
Handle missing story options from API

### DIFF
--- a/__tests__/randomizeButton.test.tsx
+++ b/__tests__/randomizeButton.test.tsx
@@ -3,18 +3,24 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 jest.mock('../app/components/Story', () => () => null);
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+jest.mock('../app/providers/LanguageProvider', () => ({
+  useLanguage: () => ({ locale: 'es' }),
+}));
 import StoryForm from '../app/components/StoryForm';
 
 describe('StoryForm randomizer', () => {
   test('muestra botón Randomizar', () => {
     render(<StoryForm />);
-    expect(screen.getByRole('button', { name: /randomizar/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /randomize/i })).toBeInTheDocument();
   });
 
   test('al pulsar Randomizar se genera una configuración', () => {
     const spy = jest.spyOn(Math, 'random').mockReturnValue(0);
     render(<StoryForm />);
-    fireEvent.click(screen.getByRole('button', { name: /randomizar/i }));
+    fireEvent.click(screen.getByRole('button', { name: /randomize/i }));
     expect(screen.getAllByText('Aventura', { selector: 'span' })[0]).toBeInTheDocument();
     expect(screen.getByText('ligero')).toBeInTheDocument();
     expect(screen.getByText('infantil')).toBeInTheDocument();

--- a/__tests__/storyMissingOptions.test.tsx
+++ b/__tests__/storyMissingOptions.test.tsx
@@ -1,0 +1,50 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Story from '../app/components/Story';
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+jest.mock('../app/providers/LanguageProvider', () => ({
+  useLanguage: () => ({ locale: 'es' }),
+}));
+
+describe('Story options regeneration', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ text: 'Nuevo capítulo\nOpción única' }),
+    }) as jest.Mock;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('loggea error si la API devuelve menos opciones de las esperadas', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <Story
+        initialStory="Inicio"
+        initialOptions={['Uno', 'Dos']}
+        optionsPerDecision={2}
+        endingMode="infinita"
+        genres={[]}
+        estilo={{}}
+        ajustes={{}}
+        onBack={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Uno'));
+
+    await waitFor(() => expect(consoleSpy).toHaveBeenCalled());
+    expect(screen.getByText('Opción única')).toBeInTheDocument();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'La API devolvió menos opciones de las esperadas'
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/app/components/Story.tsx
+++ b/app/components/Story.tsx
@@ -131,10 +131,13 @@ export default function Story({
       setChoices((prev) => [...prev, option]);
       setCurrentChapter(nextChapter);
 
-      let opts = Array.from(new Set(newOptions.filter(Boolean))).slice(
-        0,
-        optionsPerDecision
-      );
+      let opts = Array.from(new Set(newOptions.filter(Boolean)));
+      if (opts.length < optionsPerDecision) {
+        console.error(
+          'La API devolvió menos opciones de las esperadas'
+        );
+      }
+      opts = opts.slice(0, optionsPerDecision);
 
       let end = false;
       if (endingMode === 'capitulos') {


### PR DESCRIPTION
## Summary
- log an error when the story API returns fewer options than expected
- add tests covering insufficient option scenarios and adjust existing tests for mocked translations

## Testing
- `npm test` *(fails: Missing script)*
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68a52fd6001083299a3428da775cd4d4