### PR TITLE
Add default timezone to LanguageProvider

### DIFF
--- a/app/providers/LanguageProvider.tsx
+++ b/app/providers/LanguageProvider.tsx
@@ -14,6 +14,9 @@ export const useLanguage = () => useContext(LanguageContext);
 export default function LanguageProvider({ children }: { children: ReactNode }) {
   const [locale, setLocale] = useState('es');
   const [messages, setMessages] = useState<Record<string, any>>({});
+  const [timeZone] = useState(
+    () => Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+  );
 
   useEffect(() => {
     const initial = navigator.language?.split('-')[0] || 'es';
@@ -29,7 +32,11 @@ export default function LanguageProvider({ children }: { children: ReactNode }) 
 
   return (
     <LanguageContext.Provider value={{ locale, setLocale }}>
-      <NextIntlClientProvider locale={locale} messages={messages}>
+      <NextIntlClientProvider
+        locale={locale}
+        messages={messages}
+        timeZone={timeZone}
+      >
         {children}
       </NextIntlClientProvider>
     </LanguageContext.Provider>


### PR DESCRIPTION
## Summary
- compute a default time zone and pass it to `NextIntlClientProvider`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt, no linting run)*

------
https://chatgpt.com/codex/tasks/task_e_68a53354a4608329a441bf21892a21a9