### PR TITLE
Guard translations until messages load

### DIFF
--- a/app/providers/LanguageProvider.tsx
+++ b/app/providers/LanguageProvider.tsx
@@ -14,6 +14,7 @@ export const useLanguage = () => useContext(LanguageContext);
 export default function LanguageProvider({ children }: { children: ReactNode }) {
   const [locale, setLocale] = useState('es');
   const [messages, setMessages] = useState<Record<string, any>>({});
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     const initial = navigator.language?.split('-')[0] || 'es';
@@ -21,11 +22,17 @@ export default function LanguageProvider({ children }: { children: ReactNode }) 
   }, []);
 
   useEffect(() => {
+    setLoaded(false);
     fetch(`/locales/${locale}/messages.json`)
       .then(res => res.json())
       .then(setMessages)
-      .catch(() => setMessages({}));
+      .catch(() => setMessages({}))
+      .finally(() => setLoaded(true));
   }, [locale]);
+
+  if (!loaded || Object.keys(messages).length === 0) {
+    return null;
+  }
 
   return (
     <LanguageContext.Provider value={{ locale, setLocale }}>


### PR DESCRIPTION
## Summary
- Track when translation messages finish loading
- Render `NextIntlClientProvider` only after messages have loaded
- Prevent components from using `useTranslations` with empty messages

## Testing
- `npx jest` *(fails: storyMissingOptions.test.tsx expects 'Opción única')*

------
https://chatgpt.com/codex/tasks/task_e_68a53354d7848329bc0e26c57973f42a