### PR TITLE
feat: add interactive story screen

### DIFF
--- a/TheNoRealApp/app/Story.tsx
+++ b/TheNoRealApp/app/Story.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+interface StoryResponse {
+  text: string;
+  options: string[];
+}
+
+export default function Story() {
+  const [story, setStory] = useState('');
+  const [options, setOptions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStory = async (option?: string) => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await fetch('/api/story', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ option }),
+      });
+      const data: StoryResponse = await res.json();
+      setStory((prev) => (prev ? prev + '\n\n' : '') + data.text);
+      setOptions(data.options);
+    } catch (e) {
+      console.error(e);
+      setError('Failed to load story');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchStory();
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Text>{story}</Text>
+      {loading && <Text>Loading...</Text>}
+      {error && <Text>{error}</Text>}
+      {options.map((opt, idx) => (
+        <Button
+          key={idx}
+          title={opt}
+          onPress={() => fetchStory(opt)}
+          disabled={loading}
+        />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    gap: 8,
+  },
+});
+


### PR DESCRIPTION
## Summary
- add Story screen to display generated text
- render options as buttons and fetch continuations
- manage loading and error states with React hooks

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a68f5963d48329b96b1ae5f9586738