### PR TITLE
refactor: replace expo-image with React Native Image

### DIFF
--- a/TheNoRealApp/app.json
+++ b/TheNoRealApp/app.json
@@ -18,15 +18,16 @@
       },
       "edgeToEdgeEnabled": true
     },
-    "web": {
-      "bundler": "metro",
-      "output": "static",
-      "favicon": "./assets/images/favicon.png"
-    },
-    "plugins": [
-      "expo-router",
-      [
-        "expo-splash-screen",
+      "web": {
+        "bundler": "metro",
+        "output": "static",
+        "favicon": "./assets/images/favicon.png"
+      },
+      "assetBundlePatterns": ["**/*"],
+      "plugins": [
+        "expo-router",
+        [
+          "expo-splash-screen",
         {
           "image": "./assets/images/splash-icon.png",
           "imageWidth": 200,

--- a/TheNoRealApp/app/(tabs)/explore.tsx
+++ b/TheNoRealApp/app/(tabs)/explore.tsx
@@ -1,5 +1,4 @@
-import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
+import { Image, Platform, StyleSheet } from 'react-native';
 
 import { Collapsible } from '@/components/Collapsible';
 import { ExternalLink } from '@/components/ExternalLink';

--- a/TheNoRealApp/app/(tabs)/index.tsx
+++ b/TheNoRealApp/app/(tabs)/index.tsx
@@ -1,5 +1,4 @@
-import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
+import { Image, Platform, StyleSheet } from 'react-native';
 
 import { HelloWave } from '@/components/HelloWave';
 import ParallaxScrollView from '@/components/ParallaxScrollView';

--- a/TheNoRealApp/constants/Colors.ts
+++ b/TheNoRealApp/constants/Colors.ts
@@ -3,24 +3,29 @@
  * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
  */
 
-const tintColorLight = '#0a7ea4';
-const tintColorDark = '#fff';
+// Pastel narrative palette converted from app/globals.css
+const accentLight = '#c3f0ca';
+const accentDark = '#5dbb63';
 
 export const Colors = {
   light: {
-    text: '#11181C',
-    background: '#fff',
-    tint: tintColorLight,
-    icon: '#687076',
-    tabIconDefault: '#687076',
-    tabIconSelected: tintColorLight,
+    text: '#3a2d4f',
+    background: '#f5e9ff',
+    tint: accentDark,
+    icon: '#3a2d4f',
+    tabIconDefault: '#3a2d4f',
+    tabIconSelected: accentDark,
+    accent: accentLight,
+    accentDark,
   },
   dark: {
-    text: '#ECEDEE',
-    background: '#151718',
-    tint: tintColorDark,
-    icon: '#9BA1A6',
-    tabIconDefault: '#9BA1A6',
-    tabIconSelected: tintColorDark,
+    text: '#f1e9f9',
+    background: '#1a1622',
+    tint: accentDark,
+    icon: '#f1e9f9',
+    tabIconDefault: '#f1e9f9',
+    tabIconSelected: '#2f855a',
+    accent: accentDark,
+    accentDark: '#2f855a',
   },
 };

--- a/TheNoRealApp/package-lock.json
+++ b/TheNoRealApp/package-lock.json
@@ -17,7 +17,6 @@
         "expo-constants": "~17.1.7",
         "expo-font": "~13.3.2",
         "expo-haptics": "~14.1.4",
-        "expo-image": "~2.4.0",
         "expo-linking": "~7.1.7",
         "expo-router": "~5.1.4",
         "expo-splash-screen": "~0.30.10",
@@ -6254,23 +6253,6 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
-      }
-    },
-    "node_modules/expo-image": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-2.4.0.tgz",
-      "integrity": "sha512-TQ/LvrtJ9JBr+Tf198CAqflxcvdhuj7P24n0LQ1jHaWIVA7Z+zYKbYHnSMPSDMul/y0U46Z5bFLbiZiSidgcNw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*",
-        "react-native-web": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-web": {
-          "optional": true
-        }
       }
     },
     "node_modules/expo-keep-awake": {

--- a/TheNoRealApp/package.json
+++ b/TheNoRealApp/package.json
@@ -20,7 +20,6 @@
     "expo-constants": "~17.1.7",
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",
-    "expo-image": "~2.4.0",
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.4",
     "expo-splash-screen": "~0.30.10",
@@ -41,9 +40,9 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~9.2.0"
+    "eslint-config-expo": "~9.2.0",
+    "typescript": "~5.8.3"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- translate `globals.css` pastel theme into React Native color constants
- replace `expo-image` with core `Image` and clean up dependency
- bundle assets and custom fonts via `assetBundlePatterns`

## Testing
- `cd TheNoRealApp && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a68f5da6ec8329b92217f3c646ae9b