### PR TITLE
Restore image generation fetch logic and cleanup

### DIFF
--- a/lib/imageGenerator.ts
+++ b/lib/imageGenerator.ts
@@ -26,7 +26,7 @@ export async function generateImage(
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
-/*
+
   try {
     const res = await fetch(SD_API, {
       method: 'POST',
@@ -76,9 +76,10 @@ export async function generateImage(
     throw error;
   } finally {
     clearTimeout(timeout);
-  }*/
+  }
+
   // Temporary fallback to satisfy return type while implementation is commented out
-  return { url: null, truncated: false };
+  return { url: null, truncated };
 }
 
 export default generateImage;


### PR DESCRIPTION
## Summary
- restore image fetching code with try/catch/finally and timeout cleanup
- return actual image URL and propagate truncation status

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx jest` *(fails: 1 failed, 2 passed)*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a73168fa048329824ffe66c5277a4f