### PR TITLE
Use locale locale-specific TTS voice with fallback

### DIFF
--- a/app/components/Story.tsx
+++ b/app/components/Story.tsx
@@ -70,7 +70,16 @@ export default function Story({
       setIsReading(false);
     } else {
       const utterance = new SpeechSynthesisUtterance(text);
-      utterance.lang = 'es-AR'; // ajustá si querés forzar voz
+      const voices = window.speechSynthesis.getVoices();
+      const voice = voices.find((v) => v.lang === locale) ?? voices[0];
+
+      if (voice) {
+        utterance.voice = voice;
+        utterance.lang = voice.lang;
+      } else {
+        utterance.lang = locale;
+      }
+
       utterance.rate = 1.0;
       utterance.onend = () => setIsReading(false);
       window.speechSynthesis.speak(utterance);


### PR DESCRIPTION
## Summary
- use current locale for speech synthesis instead of hard-coded 'es-AR'
- add voice fallback to ensure speech works even when locale voice is missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a7316e76d483298290370bb1f839c6