### PR TITLE
Use initial config prop in StorySettings

### DIFF
--- a/TheNoRealApp/app/StorySettings.tsx
+++ b/TheNoRealApp/app/StorySettings.tsx
@@ -129,7 +129,7 @@ export const AJUSTES_SECTIONS: { key: AjustesArrayKeys; label: string; options: 
 export default function StorySettings({ config: initialConfig, onSave }: StorySettingsProps) {
   const router = useRouter();
   const intl = useIntl();
-  const [config, setConfig] = useState<ConfigGeneracion>(defaultConfig);
+  const [config, setConfig] = useState<ConfigGeneracion>(initialConfig);
   const [incluirInput, setIncluirInput] = useState('');
   const [evitarInput, setEvitarInput] = useState('');
 


### PR DESCRIPTION
## Summary
- initialize StorySettings state from the provided config prop instead of an undefined default

## Testing
- `npm test` (missing script: test)
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68a7869997f08329833efd0e7e04defa