### PR TITLE
feat: sync story settings with initial config

### DIFF
--- a/TheNoRealApp/app/StorySettings.tsx
+++ b/TheNoRealApp/app/StorySettings.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -132,6 +132,10 @@ export default function StorySettings({ config: initialConfig, onSave }: StorySe
   const [config, setConfig] = useState<ConfigGeneracion>(defaultConfig);
   const [incluirInput, setIncluirInput] = useState('');
   const [evitarInput, setEvitarInput] = useState('');
+
+  useEffect(() => {
+    setConfig(initialConfig);
+  }, [initialConfig]);
 
   function toggleItem(section: 'estilo', key: keyof Estilo, value: string): void;
   function toggleItem(section: 'ajustes', key: AjustesArrayKeys, value: string): void;


### PR DESCRIPTION
## Summary
- keep StorySettings internal config state in sync with incoming props
- add missing React `useEffect` import

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a7869c435c8329b81fef54d0629931