### PR TITLE
refactor: replace hex colors with theme tokens

### DIFF
--- a/TheNoRealApp/app/(tabs)/explore.tsx
+++ b/TheNoRealApp/app/(tabs)/explore.tsx
@@ -6,15 +6,16 @@ import ParallaxScrollView from '../../components/ParallaxScrollView';
 import { ThemedText } from '../../components/ThemedText';
 import { ThemedView } from '../../components/ThemedView';
 import { IconSymbol } from '../../components/ui/IconSymbol';
+import { Colors } from '../../constants/Colors';
 
 export default function TabTwoScreen() {
   return (
     <ParallaxScrollView
-      headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
+      headerBackgroundColor={{ light: Colors.light.exploreHeader, dark: Colors.dark.exploreHeader }}
       headerImage={
         <IconSymbol
           size={310}
-          color="#808080"
+          color={Colors.light.muted}
           name="chevron.left.forwardslash.chevron.right"
           style={styles.headerImage}
         />
@@ -97,7 +98,7 @@ export default function TabTwoScreen() {
 
 const styles = StyleSheet.create({
   headerImage: {
-    color: '#808080',
+    color: Colors.light.muted,
     bottom: -90,
     left: -35,
     position: 'absolute',

--- a/TheNoRealApp/app/(tabs)/index.tsx
+++ b/TheNoRealApp/app/(tabs)/index.tsx
@@ -4,11 +4,12 @@ import { HelloWave } from '../../components/HelloWave';
 import ParallaxScrollView from '../../components/ParallaxScrollView';
 import { ThemedText } from '../../components/ThemedText';
 import { ThemedView } from '../../components/ThemedView';
+import { Colors } from '../../constants/Colors';
 
 export default function HomeScreen() {
   return (
     <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
+      headerBackgroundColor={{ light: Colors.light.homeHeader, dark: Colors.dark.homeHeader }}
       headerImage={
         <Image
           source={require('../../assets/images/partial-react-logo.png')}

--- a/TheNoRealApp/app/StoryForm.tsx
+++ b/TheNoRealApp/app/StoryForm.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl';
 
 import { useLanguage } from './providers/LanguageProvider';
 import { parseStoryResponse } from '../lib/parseStoryResponse';
+import { Colors } from '../constants/Colors';
 
 const GENRES = [
   'Aventura',
@@ -285,7 +286,7 @@ export default function StoryForm() {
             <Button
               title={m.label}
               onPress={() => setModality(m.key)}
-              color={modality === m.key ? '#2563eb' : undefined}
+              color={modality === m.key ? Colors.light.primary : undefined}
             />
           </View>
         ))}
@@ -349,7 +350,7 @@ const styles = StyleSheet.create({
   textarea: {
     height: 120,
     borderWidth: 1,
-    borderColor: '#ccc',
+    borderColor: Colors.light.border,
     borderRadius: 8,
     padding: 8,
     marginBottom: 4,
@@ -375,7 +376,7 @@ const styles = StyleSheet.create({
   inputSmall: {
     width: 60,
     borderWidth: 1,
-    borderColor: '#ccc',
+    borderColor: Colors.light.border,
     borderRadius: 8,
     padding: 4,
     marginLeft: 8,

--- a/TheNoRealApp/app/StorySettings.tsx
+++ b/TheNoRealApp/app/StorySettings.tsx
@@ -13,6 +13,7 @@ import { useRouter } from 'expo-router';
 import { useIntl } from 'react-intl';
 // OJO: este archivo está en TheNoRealApp/components, no en app/components
 import LanguageSelector from '../components/LanguageSelector';
+import { Colors } from '../constants/Colors';
 
 export interface Estilo {
   tono: string[];
@@ -460,14 +461,14 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     paddingHorizontal: 10,
     borderWidth: 1,
-    borderColor: '#ccc',
+    borderColor: Colors.light.border,
     borderRadius: 6,
     marginRight: 8,
     marginBottom: 8,
   },
-  optionSelected: { backgroundColor: '#e5e5e5' },
-  input: { borderWidth: 1, borderColor: '#ccc', borderRadius: 6, padding: 8 },
+  optionSelected: { backgroundColor: Colors.light.surface },
+  input: { borderWidth: 1, borderColor: Colors.light.border, borderRadius: 6, padding: 8 },
   tags: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 8 },
-  tag: { paddingVertical: 4, paddingHorizontal: 8, backgroundColor: '#e5e5e5', borderRadius: 12, marginRight: 6, marginBottom: 6 },
+  tag: { paddingVertical: 4, paddingHorizontal: 8, backgroundColor: Colors.light.surface, borderRadius: 12, marginRight: 6, marginBottom: 6 },
   buttons: { flexDirection: 'row', justifyContent: 'flex-end', gap: 8, marginBottom: 32 },
 });

--- a/TheNoRealApp/app/index.tsx
+++ b/TheNoRealApp/app/index.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl';
 
 import { useSettings } from '../context/SettingsContext';
 import LanguageSelector from './components/LanguageSelector';
+import { Colors } from '../constants/Colors';
 
 export default function StoryForm() {
   const navigation = useNavigation<any>();
@@ -42,7 +43,7 @@ const styles = StyleSheet.create({
   title: { fontSize: 24, marginBottom: 12 },
   input: {
     borderWidth: 1,
-    borderColor: '#ccc',
+    borderColor: Colors.light.border,
     padding: 8,
     marginBottom: 12,
   },

--- a/TheNoRealApp/components/ThemedText.tsx
+++ b/TheNoRealApp/components/ThemedText.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet, Text, type TextProps } from 'react-native';
 
 import { useThemeColor } from '../hooks/useThemeColor';
+import { Colors } from '../constants/Colors';
 
 export type ThemedTextProps = TextProps & {
   lightColor?: string;
@@ -55,6 +56,6 @@ const styles = StyleSheet.create({
   link: {
     lineHeight: 30,
     fontSize: 16,
-    color: '#0a7ea4',
+    color: Colors.light.link,
   },
 });

--- a/TheNoRealApp/constants/Colors.ts
+++ b/TheNoRealApp/constants/Colors.ts
@@ -7,6 +7,16 @@
 const accentLight = '#c3f0ca';
 const accentDark = '#5dbb63';
 
+const linkColor = '#0a7ea4';
+const primaryBlue = '#2563eb';
+const borderGray = '#ccc';
+const mutedGray = '#808080';
+const surfaceGray = '#e5e5e5';
+const homeHeaderLight = '#A1CEDC';
+const homeHeaderDark = '#1D3D47';
+const exploreHeaderLight = '#D0D0D0';
+const exploreHeaderDark = '#353636';
+
 export const Colors = {
   light: {
     text: '#3a2d4f',
@@ -17,6 +27,13 @@ export const Colors = {
     tabIconSelected: accentDark,
     accent: accentLight,
     accentDark,
+    link: linkColor,
+    primary: primaryBlue,
+    border: borderGray,
+    muted: mutedGray,
+    surface: surfaceGray,
+    homeHeader: homeHeaderLight,
+    exploreHeader: exploreHeaderLight,
   },
   dark: {
     text: '#f1e9f9',
@@ -27,5 +44,12 @@ export const Colors = {
     tabIconSelected: '#2f855a',
     accent: accentDark,
     accentDark: '#2f855a',
+    link: linkColor,
+    primary: primaryBlue,
+    border: borderGray,
+    muted: mutedGray,
+    surface: surfaceGray,
+    homeHeader: homeHeaderDark,
+    exploreHeader: exploreHeaderDark,
   },
 };


### PR DESCRIPTION
## Summary
- centralize previously hardcoded colors in `Colors` constants
- use theme color tokens across StoryForm, StorySettings, index pages, and ThemedText

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7988051b08329a063bdce45506ae6