### PR TITLE
feat: add gradient background to root layout

### DIFF
--- a/TheNoRealApp/app/_layout.tsx
+++ b/TheNoRealApp/app/_layout.tsx
@@ -3,11 +3,13 @@ import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
+import { StyleSheet, View } from 'react-native';
 
 import { useColorScheme } from '../hooks/useColorScheme';
 import { SettingsProvider } from '../context/SettingsContext';
 import LanguageProvider from './providers/LanguageProvider';
 import { useIntl } from 'react-intl';
+import { Colors } from '../constants/Colors';
 
 function LayoutInner() {
   const colorScheme = useColorScheme();
@@ -22,17 +24,23 @@ function LayoutInner() {
   }
 
   return (
-    <SettingsProvider>
-      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack>
-          <Stack.Screen name="index" options={{ title: 'Home' }} />
-          <Stack.Screen name="Story" options={{ title: 'Story' }} />
-          <Stack.Screen name="story-settings" options={{ title: 'Settings' }} />
-          <Stack.Screen name="+not-found" />
-        </Stack>
-        <StatusBar style="auto" />
-      </ThemeProvider>
-    </SettingsProvider>
+    <View
+      style={
+        colorScheme === 'dark' ? styles.darkContainer : styles.lightContainer
+      }
+    >
+      <SettingsProvider>
+        <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <Stack>
+            <Stack.Screen name="index" options={{ title: 'Home' }} />
+            <Stack.Screen name="Story" options={{ title: 'Story' }} />
+            <Stack.Screen name="story-settings" options={{ title: 'Settings' }} />
+            <Stack.Screen name="+not-found" />
+          </Stack>
+          <StatusBar style="auto" />
+        </ThemeProvider>
+      </SettingsProvider>
+    </View>
   );
 }
 
@@ -43,3 +51,14 @@ export default function RootLayout() {
     </LanguageProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  lightContainer: {
+    flex: 1,
+    background: `linear-gradient(135deg, ${Colors.light.background}, ${Colors.light.accent})`,
+  },
+  darkContainer: {
+    flex: 1,
+    background: `linear-gradient(135deg, ${Colors.dark.background}, ${Colors.dark.accent})`,
+  },
+});


### PR DESCRIPTION
## Summary
- add light and dark gradient containers using theme colors
- apply gradient style to app root view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx jest`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a798844aa88329a6355da3dcce9357