### PR TITLE
Use accent colors for tab headers

### DIFF
--- a/TheNoRealApp/app/(tabs)/explore.tsx
+++ b/TheNoRealApp/app/(tabs)/explore.tsx
@@ -6,11 +6,15 @@ import ParallaxScrollView from '../../components/ParallaxScrollView';
 import { ThemedText } from '../../components/ThemedText';
 import { ThemedView } from '../../components/ThemedView';
 import { IconSymbol } from '../../components/ui/IconSymbol';
+import { Colors } from '../../constants/Colors';
 
 export default function TabTwoScreen() {
   return (
     <ParallaxScrollView
-      headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
+      headerBackgroundColor={{
+        light: Colors.light.accent,
+        dark: Colors.dark.accentDark,
+      }}
       headerImage={
         <IconSymbol
           size={310}
@@ -20,7 +24,12 @@ export default function TabTwoScreen() {
         />
       }>
       <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Explore</ThemedText>
+        <ThemedText
+          type="title"
+          lightColor={Colors.light.text}
+          darkColor={Colors.dark.text}>
+          Explore
+        </ThemedText>
       </ThemedView>
       <ThemedText>This app includes example code to help you get started.</ThemedText>
       <Collapsible title="File-based routing">

--- a/TheNoRealApp/app/(tabs)/index.tsx
+++ b/TheNoRealApp/app/(tabs)/index.tsx
@@ -4,11 +4,15 @@ import { HelloWave } from '../../components/HelloWave';
 import ParallaxScrollView from '../../components/ParallaxScrollView';
 import { ThemedText } from '../../components/ThemedText';
 import { ThemedView } from '../../components/ThemedView';
+import { Colors } from '../../constants/Colors';
 
 export default function HomeScreen() {
   return (
     <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
+      headerBackgroundColor={{
+        light: Colors.light.accent,
+        dark: Colors.dark.accentDark,
+      }}
       headerImage={
         <Image
           source={require('../../assets/images/partial-react-logo.png')}
@@ -16,7 +20,12 @@ export default function HomeScreen() {
         />
       }>
       <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Welcome!</ThemedText>
+        <ThemedText
+          type="title"
+          lightColor={Colors.light.text}
+          darkColor={Colors.dark.text}>
+          Welcome!
+        </ThemedText>
         <HelloWave />
       </ThemedView>
       <ThemedView style={styles.stepContainer}>


### PR DESCRIPTION
## Summary
- use light/dark accent colors for ParallaxScrollView headers in tab screens
- ensure tab header titles use themed text colors for contrast

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `cd TheNoRealApp && npm test` *(fails: Missing script: "test")*
- `cd TheNoRealApp && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a79881dc488329bcb5ac0a22db0dfd