### PR TITLE
Graceful error when GROQ key missing

### DIFF
--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -6,8 +6,8 @@ import path from "path";
 export async function POST(req: Request) {
   if (!process.env.GROQ_API_KEY) {
     return NextResponse.json(
-      { error: "GROQ_API_KEY is not defined" },
-      { status: 500 }
+      { error: "GROQ_API_KEY no configurada" },
+      { status: 400 }
     );
   }
 

--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -407,7 +407,13 @@ export default function StoryForm() {
         </p>
       )}
 
-      {error && <p className="text-red-500">{error}</p>}
+      {error && (
+        <p className="text-red-500">
+          {error === 'GROQ_API_KEY no configurada'
+            ? 'La clave de la API de Groq no está configurada.'
+            : error}
+        </p>
+      )}
 
       <StorySettings
         open={open}


### PR DESCRIPTION
## Summary
- return 400 with clear message when GROQ_API_KEY env var is absent
- show specific warning in StoryForm when that error occurs

## Testing
- `npm test`
- `npx jest`
- `npm run lint` *(fails: interactive prompt for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a038e0948329a5e95b2776d707cf