### PR TITLE
docs: explain cache reset after editing globals.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Actualizar estilos globales
+
+Si modificas `app/globals.css`, reinicia el servidor de desarrollo (`npm run dev`) y limpia la caché del navegador o del service worker para que los nuevos colores se apliquen correctamente.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
## Summary
- document that after editing `app/globals.css`, developers must restart `npm run dev` and clear the browser or service worker cache to see new colors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a03b9d80832989813044deebbeaf