### PR TITLE
feat: add placeholder default export

### DIFF
--- a/TheNoRealApp/app/config/defaultConfig.ts
+++ b/TheNoRealApp/app/config/defaultConfig.ts
@@ -16,3 +16,7 @@ export const DEFAULT_CONFIG: ConfigGeneracion = {
     registro: ['neutral']
   },
 };
+
+export default function Placeholder() {
+  return null;
+}


### PR DESCRIPTION
## Summary
- add placeholder default export to defaultConfig

## Testing
- `npm test` (fails: missing script "test")
- `npm run lint` (prompts for ESLint configuration and was not run)

------
https://chatgpt.com/codex/tasks/task_e_68a7a0762258832989db9c2bb2aee707