### PR TITLE
refactor: centralize app config

### DIFF
--- a/TheNoRealApp/config/defaultConfig.ts
+++ b/TheNoRealApp/config/defaultConfig.ts
@@ -1,5 +1,5 @@
 // ajustá el import del tipo si difiere
-import type { ConfigGeneracion } from '../StorySettings';
+import type { ConfigGeneracion } from '../app/StorySettings';
 
 export const DEFAULT_CONFIG: ConfigGeneracion = {
   generos: [],


### PR DESCRIPTION
## Summary
- move default configuration outside app directory
- update type import for new location

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a0833c408329b9dfd955a5ec2759