### PR TITLE
refactor: move pointer events none to style

### DIFF
--- a/app/components/Story.tsx
+++ b/app/components/Story.tsx
@@ -388,7 +388,10 @@ export default function Story({
 
       {/* Overlay de carga (sutil) */}
       {loading && (
-        <div className="pointer-events-none fixed inset-x-0 bottom-24 flex justify-center">
+        <div
+          className="fixed inset-x-0 bottom-24 flex justify-center"
+          style={{ pointerEvents: 'none' }}
+        >
           <div className="animate-pulse rounded-full border bg-background/80 px-3 py-1 text-xs text-muted-foreground shadow backdrop-blur">
             {t('generating')}
           </div>


### PR DESCRIPTION
## Summary
- replace `pointer-events-none` class with inline `pointerEvents: 'none'` on loading overlay

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a08629ac832980a759e270cf8101