### PR TITLE
chore: unify StorySettings route name

### DIFF
--- a/TheNoRealApp/app/StoryForm.tsx
+++ b/TheNoRealApp/app/StoryForm.tsx
@@ -306,7 +306,7 @@ export default function StoryForm() {
 
       <Button
         title={intl.formatMessage({ id: 'StoryForm.settings' })}
-        onPress={() => navigation.navigate('story-settings', { config, setConfig })}
+        onPress={() => navigation.navigate('StorySettings', { config, setConfig })}
       />
 
       <View style={styles.genresContainer}>

--- a/TheNoRealApp/app/_layout.tsx
+++ b/TheNoRealApp/app/_layout.tsx
@@ -32,7 +32,7 @@ function LayoutInner() {
           <Stack>
             <Stack.Screen name="index" options={{ title: 'Home' }} />
             <Stack.Screen name="Story" options={{ title: 'Story' }} />
-            <Stack.Screen name="story-settings" options={{ title: 'Settings' }} />
+            <Stack.Screen name="StorySettings" options={{ title: 'Settings' }} />
             <Stack.Screen name="+not-found" />
           </Stack>
           <StatusBar style="auto" />

--- a/TheNoRealApp/app/index.tsx
+++ b/TheNoRealApp/app/index.tsx
@@ -29,7 +29,7 @@ export default function StoryForm() {
       />
       <Button
         title={intl.formatMessage({ id: 'StoryForm.settings' })}
-        onPress={() => navigation.navigate('story-settings')}
+        onPress={() => navigation.navigate('StorySettings')}
       />
       <Text style={styles.tokens}>
         {intl.formatMessage({ id: 'StoryForm.tokens' }, { count: tokenCount })}

--- a/TheNoRealApp/app/story-settings.tsx
+++ b/TheNoRealApp/app/story-settings.tsx
@@ -1,2 +1,0 @@
-import StorySettings from './StorySettings';
-export default StorySettings;


### PR DESCRIPTION
## Summary
- remove redundant `story-settings` alias
- update navigation and stack routes to `StorySettings`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a7afc05f5c8329bad5995f818d6ecc