### PR TITLE
Replace Tailwind shadow utility with inline box-shadow style

### DIFF
--- a/app/components/Story.tsx
+++ b/app/components/Story.tsx
@@ -405,7 +405,13 @@ export default function Story({
           className="fixed inset-x-0 bottom-24 flex justify-center"
           style={{ pointerEvents: 'none' }}
         >
-          <div className="animate-pulse rounded-full border bg-background/80 px-3 py-1 text-xs text-muted-foreground shadow backdrop-blur">
+          <div
+            className="animate-pulse rounded-full border bg-background/80 px-3 py-1 text-xs text-muted-foreground backdrop-blur"
+            style={{
+              boxShadow:
+                '0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px -1px rgba(0,0,0,0.1)',
+            }}
+          >
             {t('generating')}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove Tailwind `shadow` class in loading overlay and replace with explicit `boxShadow` style

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*
- `npx expo start --offline`

------
https://chatgpt.com/codex/tasks/task_e_68a7d18a9bb08329a95a7179deabad41