### PR TITLE
Use expo-linear-gradient for layout background

### DIFF
--- a/TheNoRealApp/app/_layout.tsx
+++ b/TheNoRealApp/app/_layout.tsx
@@ -3,7 +3,8 @@ import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 
 import { useColorScheme } from '../hooks/useColorScheme';
 import { SettingsProvider } from '../context/SettingsContext';
@@ -22,11 +23,20 @@ function LayoutInner() {
     return null;
   }
 
+  const gradientColors =
+    colorScheme === 'dark'
+      ? [Colors.dark.background, Colors.dark.accent]
+      : [Colors.light.background, Colors.light.accent];
+
+  const fallbackColor =
+    colorScheme === 'dark' ? Colors.dark.background : Colors.light.background;
+
   return (
-    <View
-      style={
-        colorScheme === 'dark' ? styles.darkContainer : styles.lightContainer
-      }
+    <LinearGradient
+      colors={gradientColors}
+      start={{ x: 0, y: 1 }}
+      end={{ x: 1, y: 0 }}
+      style={[styles.container, { backgroundColor: fallbackColor }]}
     >
       <SettingsProvider>
         <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
@@ -39,7 +49,7 @@ function LayoutInner() {
           <StatusBar style="auto" />
         </ThemeProvider>
       </SettingsProvider>
-    </View>
+    </LinearGradient>
   );
 }
 
@@ -52,12 +62,7 @@ export default function RootLayout() {
 }
 
 const styles = StyleSheet.create({
-  lightContainer: {
+  container: {
     flex: 1,
-    backgroundColor: `linear-gradient(135deg, ${Colors.light.background}, ${Colors.light.accent})`,
-  },
-  darkContainer: {
-    flex: 1,
-    backgroundColor: `linear-gradient(135deg, ${Colors.dark.background}, ${Colors.dark.accent})`,
   },
 });

--- a/TheNoRealApp/package-lock.json
+++ b/TheNoRealApp/package-lock.json
@@ -19,6 +19,7 @@
         "expo-font": "~13.3.2",
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.4.0",
+        "expo-linear-gradient": "^13.0.2",
         "expo-linking": "~7.1.7",
         "expo-router": "~5.1.4",
         "expo-speech": "~13.1.0",
@@ -6462,6 +6463,15 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-13.0.2.tgz",
+      "integrity": "sha512-EDcILUjRKu4P1rtWcwciN6CSyGtH7Bq4ll3oTRV7h3h8oSzSilH1g6z7kTAMlacPBKvMnkkWOGzW6KtgMKEiTg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-linking": {

--- a/TheNoRealApp/package.json
+++ b/TheNoRealApp/package.json
@@ -22,6 +22,7 @@
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.4.0",
+    "expo-linear-gradient": "^13.0.2",
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.4",
     "expo-speech": "~13.1.0",


### PR DESCRIPTION
## Summary
- replace CSS gradient strings with expo-linear-gradient background
- provide solid color fallback if gradient fails
- add expo-linear-gradient dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for configuration)*
- `npm test` in `TheNoRealApp` *(fails: Missing script "test")*
- `npm run lint` in `TheNoRealApp`
- `npx expo export -p web`
- `CI=1 npx expo start --port 8082`


------
https://chatgpt.com/codex/tasks/task_e_68a7d18bf3ec832982bd6e644d6d618d