### PR TITLE
feat: refine spanish story prompts

### DIFF
--- a/TheNoRealApp/app/locales/es/api.json
+++ b/TheNoRealApp/app/locales/es/api.json
@@ -1,17 +1,29 @@
 {
   "system": {
-    "intro": "Eres un generador de historias ramificadas y únicas, que nunca deben repetirse.",
+    "intro": "Eres un generador de historias ramificadas y únicas. Nunca repitas la misma historia.",
+    "language": "Escribe siempre en el idioma configurado (por defecto: español). No cambies de idioma.",
     "chapterLimit": "Si el capítulo actual coincide con el número máximo de capítulos configurado, debes generar un FINAL en lugar de un capítulo nuevo.",
-    "finalMode": "Si la modalidad de final es 'sorpresa' o 'cerrado', puedes elegir aleatoriamente en qué capítulo terminar, pero siempre generando un FINAL.",
-    "finalText": "Cuando sea un FINAL, escribe únicamente el texto del desenlace sin generar opciones y muestra la palabra FINALIZADO o similar.",
-    "nonFinal": "Cuando NO sea el final: responde con el texto del siguiente capítulo, luego una línea que contenga solo '---', y después las opciones numeradas, cada una en una línea separada.",
-    "noExtra": "No añadas texto adicional fuera de la historia y las opciones."
+    "finalMode": "Si la modalidad de final es 'sorpresa' o 'cerrado', puedes terminar en un capítulo aleatorio, pero siempre generando un FINAL.",
+    "finalText": "Cuando sea un FINAL, escribe únicamente el texto del desenlace y termina con la palabra EXACTA: FINALIZADO",
+    "nonFinal": "Cuando NO sea el final: escribe el texto del siguiente capítulo, luego una línea que contenga exactamente '---', y después las opciones numeradas, cada una en su propia línea.",
+    "optionsFormat": "Las opciones deben tener el formato exacto: '1. ...', '2. ...', etc. Sin paréntesis, guiones u otros símbolos. No incluyas títulos ni explicaciones.",
+    "separator": "El separador entre capítulo y opciones debe ser una línea única con tres guiones: ---",
+    "noExtra": "No añadas texto fuera de la historia y las opciones. No expliques lo que haces. No uses markdown.",
+    "uniqueness": "Evita repeticiones literales y mantén coherencia con lo ya escrito."
   },
   "user": {
-    "final": "Genera el final de la historia.",
-    "continue": "Opción elegida: {option}\n\nGenera {options} opciones para continuar la historia."
+    "final": "Genera el FINAL de la historia ahora.",
+    "continue": "Opción elegida: {option}\n\nGenera exactamente {options} opciones nuevas y coherentes para continuar la historia."
+  },
+  "constraints": {
+    "optionsPerDecision": "{options}",
+    "chapterLength": "Mantén una longitud razonable y enfocada en la acción (no divagues)."
   },
   "genreLine": "Géneros a respetar: {genres}.",
   "styleTitle": "Estilo",
-  "settingsTitle": "Ajustes"
+  "settingsTitle": "Ajustes",
+  "outputExamples": {
+    "nonFinal": "Texto del capítulo...\n---\n1. Primera opción\n2. Segunda opción\n3. Tercera opción",
+    "final": "Texto del desenlace...\nFINALIZADO"
+  }
 }

--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -78,11 +78,15 @@ export async function POST(req: Request) {
 
     const systemPrompt = [
       t('system.intro'),
+      t('system.language'),
       t('system.chapterLimit'),
       t('system.finalMode'),
       t('system.finalText'),
       t('system.nonFinal'),
+      t('system.optionsFormat'),
+      t('system.separator'),
       t('system.noExtra'),
+      t('system.uniqueness'),
       genreLine,
       estiloLine,
       ajustesLine,

--- a/public/locales/es/api.json
+++ b/public/locales/es/api.json
@@ -1,17 +1,29 @@
 {
   "system": {
-    "intro": "Eres un generador de historias ramificadas y únicas, que nunca deben repetirse.",
+    "intro": "Eres un generador de historias ramificadas y únicas. Nunca repitas la misma historia.",
+    "language": "Escribe siempre en el idioma configurado (por defecto: español). No cambies de idioma.",
     "chapterLimit": "Si el capítulo actual coincide con el número máximo de capítulos configurado, debes generar un FINAL en lugar de un capítulo nuevo.",
-    "finalMode": "Si la modalidad de final es 'sorpresa' o 'cerrado', puedes elegir aleatoriamente en qué capítulo terminar, pero siempre generando un FINAL.",
-    "finalText": "Cuando sea un FINAL, escribe únicamente el texto del desenlace sin generar opciones y muestra la palabra FINALIZADO o similar.",
-    "nonFinal": "Cuando NO sea el final: responde con el texto del siguiente capítulo, luego una línea que contenga solo '---', y después las opciones numeradas, cada una en una línea separada.",
-    "noExtra": "No añadas texto adicional fuera de la historia y las opciones."
+    "finalMode": "Si la modalidad de final es 'sorpresa' o 'cerrado', puedes terminar en un capítulo aleatorio, pero siempre generando un FINAL.",
+    "finalText": "Cuando sea un FINAL, escribe únicamente el texto del desenlace y termina con la palabra EXACTA: FINALIZADO",
+    "nonFinal": "Cuando NO sea el final: escribe el texto del siguiente capítulo, luego una línea que contenga exactamente '---', y después las opciones numeradas, cada una en su propia línea.",
+    "optionsFormat": "Las opciones deben tener el formato exacto: '1. ...', '2. ...', etc. Sin paréntesis, guiones u otros símbolos. No incluyas títulos ni explicaciones.",
+    "separator": "El separador entre capítulo y opciones debe ser una línea única con tres guiones: ---",
+    "noExtra": "No añadas texto fuera de la historia y las opciones. No expliques lo que haces. No uses markdown.",
+    "uniqueness": "Evita repeticiones literales y mantén coherencia con lo ya escrito."
   },
   "user": {
-    "final": "Genera el final de la historia.",
-    "continue": "Opción elegida: {option}\n\nGenera {options} opciones para continuar la historia."
+    "final": "Genera el FINAL de la historia ahora.",
+    "continue": "Opción elegida: {option}\n\nGenera exactamente {options} opciones nuevas y coherentes para continuar la historia."
+  },
+  "constraints": {
+    "optionsPerDecision": "{options}",
+    "chapterLength": "Mantén una longitud razonable y enfocada en la acción (no divagues)."
   },
   "genreLine": "Géneros a respetar: {genres}.",
   "styleTitle": "Estilo",
-  "settingsTitle": "Ajustes"
+  "settingsTitle": "Ajustes",
+  "outputExamples": {
+    "nonFinal": "Texto del capítulo...\n---\n1. Primera opción\n2. Segunda opción\n3. Tercera opción",
+    "final": "Texto del desenlace...\nFINALIZADO"
+  }
 }


### PR DESCRIPTION
## Summary
- expand Spanish locale system prompts and user instructions
- include new prompt sections in story API builder

## Testing
- `npx jest`
- `npm run lint` *(fails: prompts ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68aa16088a2c8329bc2e3abb4f3471ae