### PR TITLE
feat: add locale keys for api instructions

### DIFF
--- a/TheNoRealApp/app/locales/en/api.json
+++ b/TheNoRealApp/app/locales/en/api.json
@@ -1,17 +1,29 @@
 {
   "system": {
     "intro": "You are a generator of branching and unique stories that must never repeat.",
+    "language": "Always write in the configured language (default: English). Do not switch languages.",
     "chapterLimit": "If the current chapter matches the configured maximum, you must generate an END instead of a new chapter.",
     "finalMode": "If the ending mode is 'surprise' or 'closed', you may randomly choose in which chapter to finish, but always generate an END.",
     "finalText": "When it is an END, write only the ending text without generating options and display the word FINISHED or similar.",
     "nonFinal": "When it is NOT the end: respond with the text of the next chapter, then a line containing only '---', and then the numbered options, each on a separate line.",
-    "noExtra": "Do not add additional text outside the story and the options."
+    "optionsFormat": "Options must have the exact format: '1. ...', '2. ...', etc. No parentheses, dashes, or other symbols. Do not include titles or explanations.",
+    "separator": "The separator between the chapter and the options must be a single line with three dashes: ---",
+    "noExtra": "Do not add text outside the story and the options. Do not explain what you are doing. Do not use markdown.",
+    "uniqueness": "Avoid literal repetitions and stay consistent with what has already been written."
   },
   "user": {
     "final": "Generate the ending of the story.",
     "continue": "Chosen option: {option}\n\nGenerate {options} options to continue the story."
   },
+  "constraints": {
+    "optionsPerDecision": "{options}",
+    "chapterLength": "Keep a reasonable length focused on the action (do not ramble)."
+  },
   "genreLine": "Genres to respect: {genres}.",
   "styleTitle": "Style",
-  "settingsTitle": "Settings"
+  "settingsTitle": "Settings",
+  "outputExamples": {
+    "nonFinal": "Chapter text...\\n---\\n1. First option\\n2. Second option\\n3. Third option",
+    "final": "Ending text...\\nFINISHED"
+  }
 }

--- a/public/locales/en-US/api.json
+++ b/public/locales/en-US/api.json
@@ -1,17 +1,29 @@
 {
   "system": {
     "intro": "You are a generator of branching and unique stories that must never repeat.",
+    "language": "Always write in the configured language (default: English). Do not switch languages.",
     "chapterLimit": "If the current chapter matches the configured maximum, you must generate an END instead of a new chapter.",
     "finalMode": "If the ending mode is 'surprise' or 'closed', you may randomly choose in which chapter to finish, but always generate an END.",
     "finalText": "When it is an END, write only the ending text without generating options and display the word FINISHED or similar.",
     "nonFinal": "When it is NOT the end: respond with the text of the next chapter, then a line containing only '---', and then the numbered options, each on a separate line.",
-    "noExtra": "Do not add additional text outside the story and the options."
+    "optionsFormat": "Options must have the exact format: '1. ...', '2. ...', etc. No parentheses, dashes, or other symbols. Do not include titles or explanations.",
+    "separator": "The separator between the chapter and the options must be a single line with three dashes: ---",
+    "noExtra": "Do not add text outside the story and the options. Do not explain what you are doing. Do not use markdown.",
+    "uniqueness": "Avoid literal repetitions and stay consistent with what has already been written."
   },
   "user": {
     "final": "Generate the ending of the story.",
     "continue": "Chosen option: {option}\n\nGenerate {options} options to continue the story."
   },
+  "constraints": {
+    "optionsPerDecision": "{options}",
+    "chapterLength": "Keep a reasonable length focused on the action (do not ramble)."
+  },
   "genreLine": "Genres to respect: {genres}.",
   "styleTitle": "Style",
-  "settingsTitle": "Settings"
+  "settingsTitle": "Settings",
+  "outputExamples": {
+    "nonFinal": "Chapter text...\\n---\\n1. First option\\n2. Second option\\n3. Third option",
+    "final": "Ending text...\\nFINISHED"
+  }
 }

--- a/public/locales/en/api.json
+++ b/public/locales/en/api.json
@@ -1,17 +1,29 @@
 {
   "system": {
     "intro": "You are a generator of branching and unique stories that must never repeat.",
+    "language": "Always write in the configured language (default: English). Do not switch languages.",
     "chapterLimit": "If the current chapter matches the configured maximum, you must generate an END instead of a new chapter.",
     "finalMode": "If the ending mode is 'surprise' or 'closed', you may randomly choose in which chapter to finish, but always generate an END.",
     "finalText": "When it is an END, write only the ending text without generating options and display the word FINISHED or similar.",
     "nonFinal": "When it is NOT the end: respond with the text of the next chapter, then a line containing only '---', and then the numbered options, each on a separate line.",
-    "noExtra": "Do not add additional text outside the story and the options."
+    "optionsFormat": "Options must have the exact format: '1. ...', '2. ...', etc. No parentheses, dashes, or other symbols. Do not include titles or explanations.",
+    "separator": "The separator between the chapter and the options must be a single line with three dashes: ---",
+    "noExtra": "Do not add text outside the story and the options. Do not explain what you are doing. Do not use markdown.",
+    "uniqueness": "Avoid literal repetitions and stay consistent with what has already been written."
   },
   "user": {
     "final": "Generate the ending of the story.",
     "continue": "Chosen option: {option}\n\nGenerate {options} options to continue the story."
   },
+  "constraints": {
+    "optionsPerDecision": "{options}",
+    "chapterLength": "Keep a reasonable length focused on the action (do not ramble)."
+  },
   "genreLine": "Genres to respect: {genres}.",
   "styleTitle": "Style",
-  "settingsTitle": "Settings"
+  "settingsTitle": "Settings",
+  "outputExamples": {
+    "nonFinal": "Chapter text...\\n---\\n1. First option\\n2. Second option\\n3. Third option",
+    "final": "Ending text...\\nFINISHED"
+  }
 }

--- a/public/locales/es-AR/api.json
+++ b/public/locales/es-AR/api.json
@@ -1,17 +1,29 @@
 {
   "system": {
     "intro": "Eres un generador de historias ramificadas y únicas, que nunca deben repetirse.",
+    "language": "Escribe siempre en el idioma configurado (por defecto: español). No cambies de idioma.",
     "chapterLimit": "Si el capítulo actual coincide con el número máximo de capítulos configurado, debes generar un FINAL en lugar de un capítulo nuevo.",
     "finalMode": "Si la modalidad de final es 'sorpresa' o 'cerrado', puedes elegir aleatoriamente en qué capítulo terminar, pero siempre generando un FINAL.",
     "finalText": "Cuando sea un FINAL, escribe únicamente el texto del desenlace sin generar opciones y muestra la palabra FINALIZADO o similar.",
     "nonFinal": "Cuando NO sea el final: responde con el texto del siguiente capítulo, luego una línea que contenga solo '---', y después las opciones numeradas, cada una en una línea separada.",
-    "noExtra": "No añadas texto adicional fuera de la historia y las opciones."
+    "optionsFormat": "Las opciones deben tener el formato exacto: '1. ...', '2. ...', etc. Sin paréntesis, guiones u otros símbolos. No incluyas títulos ni explicaciones.",
+    "separator": "El separador entre capítulo y opciones debe ser una línea única con tres guiones: ---",
+    "noExtra": "No añadas texto fuera de la historia y las opciones. No expliques lo que haces. No uses markdown.",
+    "uniqueness": "Evita repeticiones literales y mantén coherencia con lo ya escrito."
   },
   "user": {
     "final": "Genera el final de la historia.",
     "continue": "Opción elegida: {option}\n\nGenera {options} opciones para continuar la historia."
   },
+  "constraints": {
+    "optionsPerDecision": "{options}",
+    "chapterLength": "Mantén una longitud razonable y enfocada en la acción (no divagues)."
+  },
   "genreLine": "Géneros a respetar: {genres}.",
   "styleTitle": "Estilo",
-  "settingsTitle": "Ajustes"
+  "settingsTitle": "Ajustes",
+  "outputExamples": {
+    "nonFinal": "Texto del capítulo...\\n---\\n1. Primera opción\\n2. Segunda opción\\n3. Tercera opción",
+    "final": "Texto del desenlace...\\nFINALIZADO"
+  }
 }

--- a/public/locales/es-MX/api.json
+++ b/public/locales/es-MX/api.json
@@ -1,17 +1,29 @@
 {
   "system": {
     "intro": "Eres un generador de historias ramificadas y únicas, que nunca deben repetirse.",
+    "language": "Escribe siempre en el idioma configurado (por defecto: español). No cambies de idioma.",
     "chapterLimit": "Si el capítulo actual coincide con el número máximo de capítulos configurado, debes generar un FINAL en lugar de un capítulo nuevo.",
     "finalMode": "Si la modalidad de final es 'sorpresa' o 'cerrado', puedes elegir aleatoriamente en qué capítulo terminar, pero siempre generando un FINAL.",
     "finalText": "Cuando sea un FINAL, escribe únicamente el texto del desenlace sin generar opciones y muestra la palabra FINALIZADO o similar.",
     "nonFinal": "Cuando NO sea el final: responde con el texto del siguiente capítulo, luego una línea que contenga solo '---', y después las opciones numeradas, cada una en una línea separada.",
-    "noExtra": "No añadas texto adicional fuera de la historia y las opciones."
+    "optionsFormat": "Las opciones deben tener el formato exacto: '1. ...', '2. ...', etc. Sin paréntesis, guiones u otros símbolos. No incluyas títulos ni explicaciones.",
+    "separator": "El separador entre capítulo y opciones debe ser una línea única con tres guiones: ---",
+    "noExtra": "No añadas texto fuera de la historia y las opciones. No expliques lo que haces. No uses markdown.",
+    "uniqueness": "Evita repeticiones literales y mantén coherencia con lo ya escrito."
   },
   "user": {
     "final": "Genera el final de la historia.",
     "continue": "Opción elegida: {option}\n\nGenera {options} opciones para continuar la historia."
   },
+  "constraints": {
+    "optionsPerDecision": "{options}",
+    "chapterLength": "Mantén una longitud razonable y enfocada en la acción (no divagues)."
+  },
   "genreLine": "Géneros a respetar: {genres}.",
   "styleTitle": "Estilo",
-  "settingsTitle": "Ajustes"
+  "settingsTitle": "Ajustes",
+  "outputExamples": {
+    "nonFinal": "Texto del capítulo...\\n---\\n1. Primera opción\\n2. Segunda opción\\n3. Tercera opción",
+    "final": "Texto del desenlace...\\nFINALIZADO"
+  }
 }

--- a/public/locales/fr-FR/api.json
+++ b/public/locales/fr-FR/api.json
@@ -1,17 +1,29 @@
 {
   "system": {
-    "intro": "You are a generator of branching and unique stories that must never repeat.",
-    "chapterLimit": "If the current chapter matches the configured maximum, you must generate an END instead of a new chapter.",
-    "finalMode": "If the ending mode is 'surprise' or 'closed', you may randomly choose in which chapter to finish, but always generate an END.",
-    "finalText": "When it is an END, write only the ending text without generating options and display the word FINISHED or similar.",
-    "nonFinal": "When it is NOT the end: respond with the text of the next chapter, then a line containing only '---', and then the numbered options, each on a separate line.",
-    "noExtra": "Do not add additional text outside the story and the options."
+    "intro": "Tu es un générateur d'histoires ramifiées et uniques. Ne répète jamais la même histoire.",
+    "language": "Écris toujours dans la langue configurée (par défaut : français). Ne change pas de langue.",
+    "chapterLimit": "Si le chapitre actuel correspond au nombre maximal de chapitres configuré, tu dois générer une FIN au lieu d'un nouveau chapitre.",
+    "finalMode": "Si le mode de fin est « surprise » ou « fermé », tu peux terminer à un chapitre aléatoire, mais toujours en générant une FIN.",
+    "finalText": "Lorsque c'est une FIN, écris uniquement le texte du dénouement et termine par le mot EXACT : TERMINÉ.",
+    "nonFinal": "Lorsque ce n'est PAS la fin : écris le texte du chapitre suivant, puis une ligne contenant exactement '---', puis les options numérotées, chacune sur sa propre ligne.",
+    "optionsFormat": "Les options doivent avoir le format exact : '1. ...', '2. ...', etc. Pas de parenthèses, tirets ou autres symboles. N'inclus pas de titres ni d'explications.",
+    "separator": "Le séparateur entre le chapitre et les options doit être une ligne unique avec trois tirets : ---",
+    "noExtra": "N'ajoute pas de texte en dehors de l'histoire et des options. N'explique pas ce que tu fais. N'utilise pas de markdown.",
+    "uniqueness": "Évite les répétitions littérales et garde la cohérence avec ce qui a déjà été écrit."
   },
   "user": {
-    "final": "Generate the ending of the story.",
-    "continue": "Chosen option: {option}\n\nGenerate {options} options to continue the story."
+    "final": "Génère la FIN de l'histoire maintenant.",
+    "continue": "Option choisie : {option}\n\nGénère exactement {options} options nouvelles et cohérentes pour continuer l'histoire."
   },
-  "genreLine": "Genres to respect: {genres}.",
+  "constraints": {
+    "optionsPerDecision": "{options}",
+    "chapterLength": "Garde une longueur raisonnable et centrée sur l'action (ne divague pas)."
+  },
+  "genreLine": "Genres à respecter : {genres}.",
   "styleTitle": "Style",
-  "settingsTitle": "Settings"
+  "settingsTitle": "Paramètres",
+  "outputExamples": {
+    "nonFinal": "Texte du chapitre...\\n---\\n1. Première option\\n2. Deuxième option\\n3. Troisième option",
+    "final": "Texte du dénouement...\\nTERMINÉ"
+  }
 }

--- a/public/locales/neutral/api.json
+++ b/public/locales/neutral/api.json
@@ -1,17 +1,29 @@
 {
   "system": {
     "intro": "Eres un generador de historias ramificadas y únicas, que nunca deben repetirse.",
+    "language": "Escribe siempre en el idioma configurado (por defecto: español). No cambies de idioma.",
     "chapterLimit": "Si el capítulo actual coincide con el número máximo de capítulos configurado, debes generar un FINAL en lugar de un capítulo nuevo.",
     "finalMode": "Si la modalidad de final es 'sorpresa' o 'cerrado', puedes elegir aleatoriamente en qué capítulo terminar, pero siempre generando un FINAL.",
     "finalText": "Cuando sea un FINAL, escribe únicamente el texto del desenlace sin generar opciones y muestra la palabra FINALIZADO o similar.",
     "nonFinal": "Cuando NO sea el final: responde con el texto del siguiente capítulo, luego una línea que contenga solo '---', y después las opciones numeradas, cada una en una línea separada.",
-    "noExtra": "No añadas texto adicional fuera de la historia y las opciones."
+    "optionsFormat": "Las opciones deben tener el formato exacto: '1. ...', '2. ...', etc. Sin paréntesis, guiones u otros símbolos. No incluyas títulos ni explicaciones.",
+    "separator": "El separador entre capítulo y opciones debe ser una línea única con tres guiones: ---",
+    "noExtra": "No añadas texto fuera de la historia y las opciones. No expliques lo que haces. No uses markdown.",
+    "uniqueness": "Evita repeticiones literales y mantén coherencia con lo ya escrito."
   },
   "user": {
     "final": "Genera el final de la historia.",
     "continue": "Opción elegida: {option}\n\nGenera {options} opciones para continuar la historia."
   },
+  "constraints": {
+    "optionsPerDecision": "{options}",
+    "chapterLength": "Mantén una longitud razonable y enfocada en la acción (no divagues)."
+  },
   "genreLine": "Géneros a respetar: {genres}.",
   "styleTitle": "Estilo",
-  "settingsTitle": "Ajustes"
+  "settingsTitle": "Ajustes",
+  "outputExamples": {
+    "nonFinal": "Texto del capítulo...\\n---\\n1. Primera opción\\n2. Segunda opción\\n3. Tercera opción",
+    "final": "Texto del desenlace...\\nFINALIZADO"
+  }
 }


### PR DESCRIPTION
## Summary
- add missing API instruction keys to English locale
- sync Spanish-based locales with new keys
- translate API keys for French locale

## Testing
- `npx jest`
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3281ecf483299d234bf35c82e37b