### PR TITLE
Use single completion request for options

### DIFF
--- a/app/api/options/route.ts
+++ b/app/api/options/route.ts
@@ -14,23 +14,29 @@ export async function POST(req: Request) {
       );
     }
 
-    const completions = await Promise.all(
-      Array.from({ length: count }).map(() =>
-        createChatCompletion({
-          model: "openai/gpt-oss-120b",
-          messages: [{ role: "user", content: prompt }],
-          n: 1,
-          temperature,
-          top_p,
-        })
-      )
-    );
+    let options: string[] = [];
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const completion = await createChatCompletion({
+        model: "openai/gpt-oss-120b",
+        messages: [{ role: "user", content: prompt }],
+        n: count,
+        temperature,
+        top_p,
+      });
 
-    const options = completions
-      .map((c) =>
-        'choices' in c ? c.choices[0]?.message?.content?.trim() : undefined
-      )
-      .filter(Boolean);
+      options = completion.choices
+        .map((choice) => choice.message.content?.trim())
+        .filter(Boolean) as string[];
+
+      console.log("options count", { expected: count, received: options.length });
+      if (options.length === count) {
+        break;
+      }
+    }
+
+    if (options.length !== count) {
+      return Response.json({ error: "Error generating options" }, { status: 502 });
+    }
 
     return Response.json({ options });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Use one `createChatCompletion` call with `n` set to requested option count
- Map completion choices to trimmed strings and log expected vs received counts
- Retry once and return HTTP 502 if the model returns the wrong number of options

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad226ee3b48329bdd2fbaedac0518f