### PR TITLE
feat: mejorar validación de opciones para historias

### DIFF
--- a/__tests__/optionGuard.test.ts
+++ b/__tests__/optionGuard.test.ts
@@ -1,0 +1,27 @@
+import { validateOptions } from '../lib/optionGuard';
+
+describe('validateOptions', () => {
+  it('provides reason for discarded options', () => {
+    const { valid, discarded } = validateOptions(
+      ['Correr', 'Ir al parque'],
+      2
+    );
+    expect(valid).toEqual(['Ir al parque']);
+    expect(discarded).toEqual([
+      expect.objectContaining({ option: 'Correr' }),
+    ]);
+    expect(discarded[0].reason).toMatch(/menos de/);
+  });
+
+  it('allows shorter options when lowering min', () => {
+    const { valid } = validateOptions(['Regresar'], 1, 1);
+    expect(valid).toEqual(['Regresar']);
+  });
+
+  it('allows longer options when increasing max', () => {
+    const longOption =
+      'Correr hacia la montaña lejana durante la tormenta eléctrica que se aproxima rápidamente';
+    const { valid } = validateOptions([longOption], 1, 2, 25);
+    expect(valid).toEqual([longOption]);
+  });
+});

--- a/__tests__/parseStoryResponse.test.ts
+++ b/__tests__/parseStoryResponse.test.ts
@@ -2,17 +2,17 @@ import { parseStoryResponse } from '../lib/parseStoryResponse';
 
 describe('parseStoryResponse', () => {
   it('separates historia y opciones con ---', () => {
-    const text = "Había una vez\n---\n1. Ir al bosque\n2. Ir al mar";
+    const text = "Había una vez\n---\n1. Ir al bosque\n2. Regresar";
     const { story, options } = parseStoryResponse(text, 2);
     expect(story).toBe('Había una vez');
-    expect(options).toEqual(['1. Ir al bosque', '2. Ir al mar']);
+    expect(options).toEqual(['Ir al bosque']);
   });
 
   it('maneja respuesta solo con opciones', () => {
-    const text = "1. Explorar la cueva\n2. Regresar";
+    const text = "1. Explorar la cueva\n2. Volver a casa";
     const { story, options } = parseStoryResponse(text, 2);
     expect(story).toBe('');
-    expect(options).toEqual(['1. Explorar la cueva', '2. Regresar']);
+    expect(options).toEqual(['Explorar la cueva', 'Volver a casa']);
   });
 
   it('reconoce opciones con distintos formatos numerados', () => {
@@ -20,16 +20,16 @@ describe('parseStoryResponse', () => {
     const { story, options } = parseStoryResponse(text, 3);
     expect(story).toBe('Historia');
     expect(options).toEqual([
-      '1) Ir al bosque',
-      '2- Ir al mar',
-      '3: Ir a la ciudad',
+      'Ir al bosque',
+      'Ir al mar',
+      'Ir a la ciudad',
     ]);
   });
 
   it.each([
-    ['1) Explorar la cueva\n2) Regresar', ['1) Explorar la cueva', '2) Regresar']],
-    ['1- Explorar la cueva\n2- Regresar', ['1- Explorar la cueva', '2- Regresar']],
-    ['1: Explorar la cueva\n2: Regresar', ['1: Explorar la cueva', '2: Regresar']],
+    ['1) Explorar la cueva\n2) Volver a casa', ['Explorar la cueva', 'Volver a casa']],
+    ['1- Explorar la cueva\n2- Volver a casa', ['Explorar la cueva', 'Volver a casa']],
+    ['1: Explorar la cueva\n2: Volver a casa', ['Explorar la cueva', 'Volver a casa']],
   ])('maneja respuesta solo con opciones con formato alternativo', (text, expected) => {
     const { story, options } = parseStoryResponse(text, 2);
     expect(story).toBe('');

--- a/__tests__/storyMissingOptions.test.tsx
+++ b/__tests__/storyMissingOptions.test.tsx
@@ -13,7 +13,8 @@ jest.mock('../app/providers/LanguageProvider', () => ({
 describe('Story options regeneration', () => {
   beforeEach(() => {
     global.fetch = jest.fn().mockResolvedValue({
-      json: () => Promise.resolve({ text: 'Nuevo capítulo\nOpción única' }),
+      json: () =>
+        Promise.resolve({ text: 'Nuevo capítulo\n---\n1. Explorar la cueva' }),
     }) as jest.Mock;
   });
 
@@ -40,7 +41,7 @@ describe('Story options regeneration', () => {
     fireEvent.click(screen.getByText('Uno'));
 
     await waitFor(() => expect(consoleSpy).toHaveBeenCalled());
-    expect(screen.getByText('Opción única')).toBeInTheDocument();
+    expect(screen.getByText('Explorar la cueva')).toBeInTheDocument();
     expect(consoleSpy).toHaveBeenCalledWith(
       'La API devolvió menos opciones de las esperadas'
     );

--- a/lib/optionGuard.ts
+++ b/lib/optionGuard.ts
@@ -15,12 +15,25 @@ export function looksLikeVerbStartEs(s: string): boolean {
   return commonImperatives.includes(first);
 }
 
-export function isValidOption(s: string, min=8, max=16): boolean {
+export type OptionDiscard = { option: string; reason: string };
+
+export function isValidOption(
+  s: string,
+  min = 2,
+  max = 16
+): { ok: boolean; reason?: string } {
   const t = normalizeOption(s);
   const words = countWords(t);
-  if (words < min || words > max) return false;
-  if (!looksLikeVerbStartEs(t)) return false;
-  return true;
+  if (words < min) {
+    return { ok: false, reason: `menos de ${min} palabras` };
+  }
+  if (words > max) {
+    return { ok: false, reason: `más de ${max} palabras` };
+  }
+  if (!looksLikeVerbStartEs(t)) {
+    return { ok: false, reason: 'no empieza con un verbo' };
+  }
+  return { ok: true };
 }
 
 export function dedupeOptions(options: string[]): string[] {
@@ -36,8 +49,25 @@ export function dedupeOptions(options: string[]): string[] {
   return out;
 }
 
-export function validateOptions(options: string[], N: number): string[] {
+export function validateOptions(
+  options: string[],
+  N: number,
+  min = 2,
+  max = 16
+): { valid: string[]; discarded: OptionDiscard[] } {
   const deduped = dedupeOptions(options);
-  const filtered = deduped.filter(o => isValidOption(o));
-  return filtered.slice(0, Math.max(0, N|0 || 0));
+  const valid: string[] = [];
+  const discarded: OptionDiscard[] = [];
+  for (const o of deduped) {
+    const { ok, reason } = isValidOption(o, min, max);
+    if (ok) {
+      valid.push(o);
+    } else {
+      discarded.push({ option: o, reason: reason || 'motivo desconocido' });
+    }
+  }
+  return {
+    valid: valid.slice(0, Math.max(0, N | 0 || 0)),
+    discarded,
+  };
 }

--- a/lib/parseStoryResponse.ts
+++ b/lib/parseStoryResponse.ts
@@ -16,26 +16,46 @@ function splitStoryAndOptions(text: string): { story: string; optionsBlock: stri
   return { story, optionsBlock };
 }
 
-export function parseStoryResponse(text: string, optionsPerDecision: number): ParseResult {
-  const raw = (text || "").trim();
+export function parseStoryResponse(
+  text: string,
+  optionsPerDecision: number
+): ParseResult {
+  const raw = (text || '').trim();
 
   // Detecta final por palabra EXACTA al final
   const finalRegex = /FINALIZADO\s*$/;
   const isFinal = finalRegex.test(raw);
 
-  const { story, optionsBlock } = splitStoryAndOptions(raw);
+  let { story, optionsBlock } = splitStoryAndOptions(raw);
   let options: string[] = [];
 
-  if (!isFinal && optionsBlock) {
-    const optLines = optionsBlock.split(/\r?\n/);
-    const parsed = optLines
-      .map(l => {
-        const m = l.match(/^\s*\d+\.\s+(.+?)\s*$/);
-        return m ? m[1] : null;
-      })
-      .filter(Boolean) as string[];
+  if (!isFinal) {
+    const optionRegex = /^\s*\d+[.\-:)]\s+(.+?)\s*$/;
+    if (!optionsBlock) {
+      const lines = raw.split(/\r?\n/);
+      if (lines.every(l => optionRegex.test(l))) {
+        // Solo opciones, sin historia
+        story = '';
+        optionsBlock = raw;
+      } else if (lines.length > 1 && lines.slice(1).every(l => optionRegex.test(l))) {
+        // Primera línea como historia, resto opciones
+        story = lines[0].trim();
+        optionsBlock = lines.slice(1).join('\n');
+      }
+    }
 
-    options = validateOptions(parsed, optionsPerDecision);
+    if (optionsBlock) {
+      const optLines = optionsBlock.split(/\r?\n/);
+      const parsed = optLines
+        .map(l => {
+          const m = l.match(optionRegex);
+          return m ? m[1] : null;
+        })
+        .filter(Boolean) as string[];
+
+      const { valid } = validateOptions(parsed, optionsPerDecision);
+      options = valid;
+    }
   }
 
   return { story, options, isFinal };


### PR DESCRIPTION
## Summary
- permitir configurar rango de palabras y conocer motivo de descarte en `optionGuard`
- ampliar el parseo de respuestas de historia y compatibilidad con formatos de numeración
- añadir pruebas para opciones cortas y largas y ajustar casos existentes

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68ad226e00688329b0f60aecb36d3366