### PR TITLE
chore: log Groq API responses

### DIFF
--- a/app/api/options/route.ts
+++ b/app/api/options/route.ts
@@ -38,6 +38,8 @@ export async function POST(req: Request) {
       return Response.json({ error: "Error generating options" }, { status: 502 });
     }
 
+    console.log("Groq options response", options);
+
     return Response.json({ options });
   } catch (err) {
     console.error(err);

--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -43,6 +43,8 @@ export async function POST(req: Request) {
     const text: string =
       completion?.choices?.[0]?.message?.content ?? completion?.choices?.[0]?.text ?? "";
 
+    console.log("Groq story response", text);
+
     if (!text) {
       return NextResponse.json({ error: "Respuesta vacía del modelo" }, { status: 502 });
     }


### PR DESCRIPTION
## Summary
- log Groq story responses for debugging
- log generated options from Groq before sending response

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68ad2c17b0988329b6bdeea091dc76e9