### PR TITLE
feat: broaden Spanish verb detection

### DIFF
--- a/__tests__/optionGuard.test.ts
+++ b/__tests__/optionGuard.test.ts
@@ -24,4 +24,20 @@ describe('validateOptions', () => {
     const { valid } = validateOptions([longOption], 1, 2, 25);
     expect(valid).toEqual([longOption]);
   });
+
+  it('recognizes common imperative endings', () => {
+    const options = [
+      'Descifra… el código',
+      'Come la comida',
+      'Apagad las luces',
+      'Proceded con cautela',
+      'Salid de aquí',
+      'Callaos ya',
+      'Caminemos juntos',
+      'Revivamos el momento',
+    ];
+    const { valid, discarded } = validateOptions(options, options.length);
+    expect(valid).toEqual(options);
+    expect(discarded).toEqual([]);
+  });
 });

--- a/lib/optionGuard.ts
+++ b/lib/optionGuard.ts
@@ -8,11 +8,16 @@ function countWords(s: string): number {
 }
 
 export function looksLikeVerbStartEs(s: string): boolean {
-  const first = normalizeOption(s).split(" ")[0]?.toLowerCase() || "";
+  const firstRaw = normalizeOption(s).split(" ")[0]?.toLowerCase() || "";
+  const first = firstRaw.replace(/[^\p{L}]+$/u, "");
   if (!first) return false;
   if (/(ar|er|ir)$/.test(first)) return true; // infinitivo
-  const commonImperatives = ["ve","haz","sigue","entra","toma","abre","mira","detén","corre","huye","busca","investiga","pregunta","enfrenta","rompe","cruza","sube","baja","miente","confiesa","llama","esconde","revela"];
-  return commonImperatives.includes(first);
+  const irregularImperatives = ["haz", "sé", "di", "pon", "sal", "ten", "ven", "ve", "detén"];
+  if (irregularImperatives.includes(first)) return true;
+  const commonEndings = ["a", "e", "ad", "ed", "id", "os", "emos", "amos"];
+  return commonEndings.some(
+    (ending) => first.length > ending.length + 1 && first.endsWith(ending)
+  );
 }
 
 export type OptionDiscard = { option: string; reason: string };


### PR DESCRIPTION
## Summary
- expand Spanish verb start heuristic to handle common imperative endings and irregular forms
- ensure options like "Descifra…" are valid
- cover new heuristic with dedicated tests

## Testing
- `npm test` (fails: Missing script: "test")
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68ad323ebd488329afb504369468f27f