### PR TITLE
Fetch extra options when initial options missing

### DIFF
--- a/__tests__/storyFormMissingOptions.test.tsx
+++ b/__tests__/storyFormMissingOptions.test.tsx
@@ -1,0 +1,71 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockStory = jest.fn(() => null);
+jest.mock('../app/components/Story', () => (props: any) => {
+  mockStory(props);
+  return null;
+});
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+jest.mock('../app/providers/LanguageProvider', () => ({
+  useLanguage: () => ({ locale: 'es' }),
+}));
+import StoryForm from '../app/components/StoryForm';
+
+describe('StoryForm fetches missing options', () => {
+  beforeEach(() => {
+    mockStory.mockClear();
+    (global.fetch as jest.Mock) = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            story: 'Capítulo inicial',
+            options: ['Opción A', 'Opción B'],
+          }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            options: ['Opción B', 'Opción C'],
+          }),
+      });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('completa opciones faltantes desde /api/options', async () => {
+    render(<StoryForm />);
+
+    fireEvent.change(
+      screen.getByLabelText(/Opciones por decisión/),
+      { target: { value: '3' } }
+    );
+
+    fireEvent.change(
+      screen.getByPlaceholderText('Escribe el inicio de la historia'),
+      { target: { value: 'Inicio de prueba' } }
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'createStory' }));
+
+    await waitFor(() => expect(mockStory).toHaveBeenCalled());
+
+    expect((global.fetch as jest.Mock).mock.calls[1][0]).toBe('/api/options');
+
+    const props = mockStory.mock.calls[0][0];
+    expect(props.initialOptions).toEqual([
+      'Opción A',
+      'Opción B',
+      'Opción C',
+    ]);
+  });
+});
+

--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -199,8 +199,39 @@ export default function StoryForm() {
           options = [],
         } = data as { story?: string; options?: string[] };
 
+        let opts = Array.from(new Set(options.filter(Boolean)));
+
+        if (opts.length < optionsPerDecision) {
+          try {
+            const missing = optionsPerDecision - opts.length;
+            const optRes = await fetch("/api/options", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                prompt: story,
+                numOptions: missing,
+                temperature: ajustesPayload.temperature,
+                top_p: ajustesPayload.top_p,
+              }),
+            });
+            const optData = await optRes.json().catch(() => ({}));
+            if (optRes.ok && Array.isArray((optData as any).options)) {
+              const extra = Array.from(
+                new Set(((optData as any).options as string[]).filter(Boolean))
+              );
+              opts = Array.from(new Set([...opts, ...extra]));
+            } else {
+              setError((optData as { error?: string }).error || "Error al obtener opciones adicionales");
+            }
+          } catch {
+            setError("Error al obtener opciones adicionales");
+          }
+        }
+
+        opts = opts.slice(0, optionsPerDecision);
+
         setInitialStory(story);
-        setInitialOptions(options);
+        setInitialOptions(opts);
         setStoryConfig({
           optionsPerDecision,
           endingMode: final,


### PR DESCRIPTION
## Summary
- fetch and merge additional options in `StoryForm` if the initial response returns too few
- deduplicate merged options before starting the story
- add test to ensure `StoryForm` retrieves missing options

## Testing
- `npx jest --runInBand`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3240050083298f4fbdb78ecaad7a