### PR TITLE
refactor: remove fallback return from image generator

### DIFF
--- a/lib/imageGenerator.ts
+++ b/lib/imageGenerator.ts
@@ -77,9 +77,6 @@ export async function generateImage(
   } finally {
     clearTimeout(timeout);
   }
-
-  // Temporary fallback to satisfy return type while implementation is commented out
-  return { url: null, truncated };
 }
 
 export default generateImage;


### PR DESCRIPTION
## Summary
- remove fallback return from `generateImage` to ensure errors are re-thrown and function returns only in try/catch

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68ade889abfc8329adf4ee6bf4592811