### PR TITLE
feat: align ending mode options

### DIFF
--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -10,16 +10,20 @@ import StorySettings, {
   AJUSTES_SECTIONS,
 } from "./StorySettings";
 
-type EndingMode = "capitulos" | "sin_final_definido" | "final_sorpresa" | "infinita";
+type EndingMode =
+  | "capitulos"
+  | "sin_final_definido"
+  | "final_sorpresa"
+  | "infinita";
 
-const MODALITY_HELP = {
+const MODALITY_HELP: Record<EndingMode, string> = {
   capitulos: "Divide la historia en capítulos.",
   final_sorpresa: "Añade un giro inesperado al final.",
-  final_abierto: "La historia queda abierta a interpretación.",
-  final_cerrado: "La historia tiene un desenlace definido.",
+  sin_final_definido: "La historia queda abierta a interpretación.",
+  infinita: "La historia continúa indefinidamente.",
 } as const;
 
-type Modality = keyof typeof MODALITY_HELP;
+type Modality = EndingMode;
 
 const GENRES = [
   "Aventura",
@@ -155,13 +159,7 @@ export default function StoryForm() {
         setPromptTruncated(true);
       }
 
-      const final: EndingMode = (() => {
-        switch (modality) {
-          case "final_abierto": return "sin_final_definido";
-          case "final_cerrado": return chaptersNum ? "capitulos" : "sin_final_definido";
-          default: return modality;
-        }
-      })();
+      const final: EndingMode = modality;
 
       const { creatividad, topP, ...restAjustes } = config.ajustes as any;
       const ajustesPayload: any = {
@@ -386,8 +384,8 @@ export default function StoryForm() {
               >
                 <option value="capitulos">Capítulos</option>
                 <option value="final_sorpresa">Final sorpresa</option>
-                <option value="final_abierto">Final abierto</option>
-                <option value="final_cerrado">Final cerrado</option>
+                <option value="sin_final_definido">Final abierto</option>
+                <option value="infinita">Historia infinita</option>
               </select>
             </div>
 


### PR DESCRIPTION
## Summary
- align EndingMode, help text, and select UI to support `capitulos`, `final_sorpresa`, `sin_final_definido`, and `infinita`
- simplify ending mode mapping during story submission

## Testing
- `npx jest`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ade88a9cbc83299c2fdc4de7e820b0