### PR TITLE
Enable image generation for chapters

### DIFF
--- a/__tests__/storyMissingOptions.test.tsx
+++ b/__tests__/storyMissingOptions.test.tsx
@@ -9,6 +9,9 @@ jest.mock('next-intl', () => ({
 jest.mock('../app/providers/LanguageProvider', () => ({
   useLanguage: () => ({ locale: 'es' }),
 }));
+jest.mock('@/lib/imageGenerator', () => ({
+  generateImage: jest.fn().mockResolvedValue({ url: null, truncated: false }),
+}));
 
 describe('Story options regeneration', () => {
   beforeEach(() => {

--- a/app/components/Story.tsx
+++ b/app/components/Story.tsx
@@ -132,12 +132,12 @@ export default function Story({
       } = data as { story?: string; options?: string[]; isFinal?: boolean };
 
       let imageUrl: string | null = null;
-      /*try {
+      try {
         const { url } = await generateImage(newStory, genres);
         imageUrl = url;
       } catch (err) {
         console.error('No se pudo generar la imagen', err);
-      }*/
+      }
 
       setChapters((prev) => [...prev, { texto: newStory, imageUrl }]);
       setChoices((prev) => [...prev, option]);


### PR DESCRIPTION
## Summary
- generate images for each chapter by calling `generateImage` in `handleSelect`
- mock `generateImage` in tests to avoid extra fetch calls

## Testing
- `npx jest`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ade88b7bb48329a95da2687da5d5e8