### PR TITLE
feat: add style hints to story prompt

### DIFF
--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import createChatCompletion from "@/lib/groqClient";
 import { SYSTEM_PROMPT_V3, buildUserMessage } from "@/lib/storyPrompt";
+import type { Estilo } from "@/types/story";
 import { buildMeta } from "@/lib/meta";
 import { computeFingerprint, pushFingerprint, getRecentFingerprints } from "@/lib/fingerprint";
 import { parseStoryResponse } from "@/lib/parseStoryResponse";
@@ -16,6 +17,19 @@ export async function POST(req: Request) {
     const chosenOption: string = body.option ?? "";
     const optionsCount: number = Number(body.optionsPerDecision ?? 2) || 2;
     const genres: string[] = Array.isArray(body.genres) ? body.genres : [];
+    const estilo: Estilo =
+      typeof body.estilo === "object" && body.estilo
+        ? body.estilo
+        : {
+            tono: [],
+            ritmo: [],
+            voz: [],
+            tiempo: [],
+            formato: [],
+            descripcion: [],
+            dialogo: [],
+            matiz: [],
+          };
     const temperature: number = typeof body.ajustes?.temperature === "number" ? body.ajustes.temperature : 0.75;
     const top_p: number = typeof body.ajustes?.top_p === "number" ? body.ajustes.top_p : 0.9;
     const targetWords: number = typeof body.ajustes?.targetWords === "number" ? body.ajustes.targetWords : 220;
@@ -29,7 +43,18 @@ export async function POST(req: Request) {
 
     const messages = [
       { role: "system", content: SYSTEM_PROMPT_V3 },
-      { role: "user", content: buildUserMessage({ text: storyText, chosenOption, optionsCount, targetWords, metaBlock }) },
+      {
+        role: "user",
+        content: buildUserMessage({
+          text: storyText,
+          chosenOption,
+          optionsCount,
+          targetWords,
+          metaBlock,
+          genres,
+          estilo,
+        }),
+      },
     ] as const;
 
     const model = process.env.GROQ_MODEL || "moonshotai/kimi-k2-instruct";

--- a/lib/storyPrompt.ts
+++ b/lib/storyPrompt.ts
@@ -1,3 +1,5 @@
+import type { Estilo } from "@/types/story";
+
 export const SYSTEM_PROMPT_V3 = `Eres un generador de historias ramificadas y únicas. No repitas tramas ni frases largas. Escribe SIEMPRE en el idioma configurado (por defecto: español). No cambies de idioma.
 
 === FORMATO ESTRICTO ===
@@ -47,7 +49,28 @@ export type BuildUserMessageArgs = {
   optionsCount: number;
   targetWords?: number;
   metaBlock?: string | null;
+  genres?: string[];
+  estilo?: Estilo;
 };
+
+function formatConfigLines(genres?: string[], estilo?: Estilo): string[] {
+  const lines: string[] = [];
+  if (genres && genres.length > 0) {
+    lines.push(`Géneros a respetar: ${genres.join(", ")}`);
+  }
+  if (estilo) {
+    const parts: string[] = [];
+    for (const [key, values] of Object.entries(estilo)) {
+      if (Array.isArray(values) && values.length > 0) {
+        parts.push(`${key} ${values.join(", ")}`);
+      }
+    }
+    if (parts.length > 0) {
+      lines.push(`Estilo: ${parts.join(", ")}`);
+    }
+  }
+  return lines;
+}
 
 export function buildUserMessage({
   text,
@@ -55,15 +78,16 @@ export function buildUserMessage({
   optionsCount,
   targetWords,
   metaBlock,
+  genres,
+  estilo,
 }: BuildUserMessageArgs): string {
   const chosen = (chosenOption ?? "") + "";
-  const lines = [
-    text.trim(),
-    "",
-    `Opción elegida: ${chosen}`,
-    "",
-    `Genera exactamente ${optionsCount} opciones nuevas y coherentes para continuar la historia.`,
-  ];
+  const lines = [text.trim(), ""];
+  const configLines = formatConfigLines(genres, estilo);
+  if (configLines.length > 0) {
+    lines.push(...configLines, "");
+  }
+  lines.push(`Opción elegida: ${chosen}`, "", `Genera exactamente ${optionsCount} opciones nuevas y coherentes para continuar la historia.`);
   if (typeof targetWords === "number") {
     // Sugerencia suave al modelo; el SYSTEM dicta cómo usarlo vía [META].
   }

--- a/public/locales/en-US/api.json
+++ b/public/locales/en-US/api.json
@@ -20,6 +20,7 @@
     "chapterLength": "Keep a reasonable length focused on the action (do not ramble)."
   },
   "genreLine": "Genres to respect: {genres}.",
+  "styleLine": "Style: {style}.",
   "styleTitle": "Style",
   "settingsTitle": "Settings",
   "outputExamples": {

--- a/public/locales/en/api.json
+++ b/public/locales/en/api.json
@@ -20,6 +20,7 @@
     "chapterLength": "Keep a reasonable length focused on the action (do not ramble)."
   },
   "genreLine": "Genres to respect: {genres}.",
+  "styleLine": "Style: {style}.",
   "styleTitle": "Style",
   "settingsTitle": "Settings",
   "outputExamples": {

--- a/public/locales/es-AR/api.json
+++ b/public/locales/es-AR/api.json
@@ -20,6 +20,7 @@
     "chapterLength": "Mantén una longitud razonable y enfocada en la acción (no divagues)."
   },
   "genreLine": "Géneros a respetar: {genres}.",
+  "styleLine": "Estilo: {style}.",
   "styleTitle": "Estilo",
   "settingsTitle": "Ajustes",
   "outputExamples": {

--- a/public/locales/es-MX/api.json
+++ b/public/locales/es-MX/api.json
@@ -20,6 +20,7 @@
     "chapterLength": "Mantén una longitud razonable y enfocada en la acción (no divagues)."
   },
   "genreLine": "Géneros a respetar: {genres}.",
+  "styleLine": "Estilo: {style}.",
   "styleTitle": "Estilo",
   "settingsTitle": "Ajustes",
   "outputExamples": {

--- a/public/locales/es/api.json
+++ b/public/locales/es/api.json
@@ -20,6 +20,7 @@
     "chapterLength": "Mantén una longitud razonable y enfocada en la acción (no divagues)."
   },
   "genreLine": "Géneros a respetar: {genres}.",
+  "styleLine": "Estilo: {style}.",
   "styleTitle": "Estilo",
   "settingsTitle": "Ajustes",
   "outputExamples": {

--- a/public/locales/fr-FR/api.json
+++ b/public/locales/fr-FR/api.json
@@ -20,6 +20,7 @@
     "chapterLength": "Garde une longueur raisonnable et centrée sur l'action (ne divague pas)."
   },
   "genreLine": "Genres à respecter : {genres}.",
+  "styleLine": "Style : {style}.",
   "styleTitle": "Style",
   "settingsTitle": "Paramètres",
   "outputExamples": {

--- a/public/locales/neutral/api.json
+++ b/public/locales/neutral/api.json
@@ -20,6 +20,7 @@
     "chapterLength": "Mantén una longitud razonable y enfocada en la acción (no divagues)."
   },
   "genreLine": "Géneros a respetar: {genres}.",
+  "styleLine": "Estilo: {style}.",
   "styleTitle": "Estilo",
   "settingsTitle": "Ajustes",
   "outputExamples": {


### PR DESCRIPTION
## Summary
- pass `estilo` through story route and include it when building the story prompt
- format genre and style lines for the model and add translations

## Testing
- `npx jest`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1bdd89588329abfacdbed6049ee1