### PR TITLE
feat: forward style to story generator

### DIFF
--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import createChatCompletion from "@/lib/groqClient";
 import { SYSTEM_PROMPT_V3, buildUserMessage } from "@/lib/storyPrompt";
+import type { Estilo } from "@/types/story";
 import { buildMeta } from "@/lib/meta";
 import { computeFingerprint, pushFingerprint, getRecentFingerprints } from "@/lib/fingerprint";
 import { parseStoryResponse } from "@/lib/parseStoryResponse";
@@ -19,6 +20,7 @@ export async function POST(req: Request) {
     const temperature: number = typeof body.ajustes?.temperature === "number" ? body.ajustes.temperature : 0.75;
     const top_p: number = typeof body.ajustes?.top_p === "number" ? body.ajustes.top_p : 0.9;
     const targetWords: number = typeof body.ajustes?.targetWords === "number" ? body.ajustes.targetWords : 220;
+    const estilo: Estilo | undefined = body.estilo;
 
     const metaBlock = buildMeta({
       optionsCount,
@@ -29,7 +31,17 @@ export async function POST(req: Request) {
 
     const messages = [
       { role: "system", content: SYSTEM_PROMPT_V3 },
-      { role: "user", content: buildUserMessage({ text: storyText, chosenOption, optionsCount, targetWords, metaBlock }) },
+      {
+        role: "user",
+        content: buildUserMessage({
+          text: storyText,
+          chosenOption,
+          optionsCount,
+          targetWords,
+          metaBlock,
+          estilo,
+        }),
+      },
     ] as const;
 
     const model = process.env.GROQ_MODEL || "moonshotai/kimi-k2-instruct";

--- a/lib/storyPrompt.ts
+++ b/lib/storyPrompt.ts
@@ -1,3 +1,5 @@
+import type { Estilo } from "@/types/story";
+
 export const SYSTEM_PROMPT_V3 = `Eres un generador de historias ramificadas y únicas. No repitas tramas ni frases largas. Escribe SIEMPRE en el idioma configurado (por defecto: español). No cambies de idioma.
 
 === FORMATO ESTRICTO ===
@@ -47,6 +49,7 @@ export type BuildUserMessageArgs = {
   optionsCount: number;
   targetWords?: number;
   metaBlock?: string | null;
+  estilo?: Estilo;
 };
 
 export function buildUserMessage({
@@ -55,6 +58,7 @@ export function buildUserMessage({
   optionsCount,
   targetWords,
   metaBlock,
+  estilo,
 }: BuildUserMessageArgs): string {
   const chosen = (chosenOption ?? "") + "";
   const lines = [
@@ -64,6 +68,24 @@ export function buildUserMessage({
     "",
     `Genera exactamente ${optionsCount} opciones nuevas y coherentes para continuar la historia.`,
   ];
+  if (estilo) {
+    const labels: Record<keyof Estilo, string> = {
+      tono: "Tono",
+      ritmo: "Ritmo",
+      voz: "Voz",
+      tiempo: "Tiempo",
+      formato: "Formato",
+      descripcion: "Descripción",
+      dialogo: "Diálogo",
+      matiz: "Matiz",
+    };
+    const estiloLines = (Object.entries(estilo) as [keyof Estilo, string[]][])
+      .filter(([, arr]) => Array.isArray(arr) && arr.length > 0)
+      .map(([key, arr]) => `${labels[key]}: ${arr.join(", ")}`);
+    if (estiloLines.length > 0) {
+      lines.push("", ...estiloLines);
+    }
+  }
   if (typeof targetWords === "number") {
     // Sugerencia suave al modelo; el SYSTEM dicta cómo usarlo vía [META].
   }


### PR DESCRIPTION
## Summary
- include optional `estilo` in `BuildUserMessageArgs`
- render style preferences in `buildUserMessage`
- pass `estilo` from API requests to `buildUserMessage`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx jest`
- `npm run lint` *(requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1c08ccd483298470a697ea44cfed