### PR TITLE
feat: add language-aware prompts

### DIFF
--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import createChatCompletion from "@/lib/groqClient";
-import { SYSTEM_PROMPT_V3, buildUserMessage } from "@/lib/storyPrompt";
+import { buildSystemPrompt, buildUserMessage } from "@/lib/storyPrompt";
 import { buildMeta } from "@/lib/meta";
 import { computeFingerprint, pushFingerprint, getRecentFingerprints } from "@/lib/fingerprint";
 import { parseStoryResponse } from "@/lib/parseStoryResponse";
@@ -16,6 +16,7 @@ export async function POST(req: Request) {
     const chosenOption: string = body.option ?? "";
     const optionsCount: number = Number(body.optionsPerDecision ?? 2) || 2;
     const genres: string[] = Array.isArray(body.genres) ? body.genres : [];
+    const language: string = typeof body.language === "string" ? body.language : "neutral";
     const temperature: number = typeof body.ajustes?.temperature === "number" ? body.ajustes.temperature : 0.75;
     const top_p: number = typeof body.ajustes?.top_p === "number" ? body.ajustes.top_p : 0.9;
     const targetWords: number = typeof body.ajustes?.targetWords === "number" ? body.ajustes.targetWords : 220;
@@ -27,9 +28,22 @@ export async function POST(req: Request) {
       bannedCliches: ["todo fue un sueño", "llamadas sin identificador", "hospital psiquiátrico abandonado"],
     });
 
+    const [systemContent, userContent] = await Promise.all([
+      buildSystemPrompt(language),
+      buildUserMessage({
+        text: storyText,
+        chosenOption,
+        optionsCount,
+        targetWords,
+        metaBlock,
+        language,
+        genres,
+      }),
+    ]);
+
     const messages = [
-      { role: "system", content: SYSTEM_PROMPT_V3 },
-      { role: "user", content: buildUserMessage({ text: storyText, chosenOption, optionsCount, targetWords, metaBlock }) },
+      { role: "system", content: systemContent },
+      { role: "user", content: userContent },
     ] as const;
 
     const model = process.env.GROQ_MODEL || "moonshotai/kimi-k2-instruct";

--- a/lib/apiLocale.ts
+++ b/lib/apiLocale.ts
@@ -1,0 +1,30 @@
+import fs from "fs/promises";
+import path from "path";
+
+export type ApiLocale = {
+  system: Record<string, string>;
+  user: Record<string, string>;
+  genreLine?: string;
+};
+
+const cache = new Map<string, ApiLocale>();
+
+export async function loadApiLocale(language: string): Promise<ApiLocale> {
+  const parts = typeof language === "string" ? language.split("-") : [];
+  const candidates = [language, parts[0], "neutral"].filter(Boolean) as string[];
+  for (const loc of candidates) {
+    if (cache.has(loc)) {
+      return cache.get(loc)!;
+    }
+    const file = path.join(process.cwd(), "public", "locales", loc, "api.json");
+    try {
+      const data = await fs.readFile(file, "utf8");
+      const json = JSON.parse(data) as ApiLocale;
+      cache.set(loc, json);
+      return json;
+    } catch {
+      // ignore and try next
+    }
+  }
+  throw new Error("API locale not found");
+}

--- a/lib/storyPrompt.ts
+++ b/lib/storyPrompt.ts
@@ -1,45 +1,9 @@
-export const SYSTEM_PROMPT_V3 = `Eres un generador de historias ramificadas y únicas. No repitas tramas ni frases largas. Escribe SIEMPRE en el idioma configurado (por defecto: español). No cambies de idioma.
+import { loadApiLocale } from "./apiLocale";
 
-=== FORMATO ESTRICTO ===
-- Si es FINAL: escribe SOLO el desenlace y termina con la palabra EXACTA: FINALIZADO
-- Si NO es final:
-  1) Escribe el texto del capítulo.
-  2) En una línea sola y exacta: ---
-  3) Escribe las opciones numeradas, cada una en su propia línea, con el formato EXACTO: "1. ...", "2. ...", etc.
-- No añadas nada fuera de historia/opciones. No uses markdown, títulos ni explicaciones. No repitas el prompt del usuario.
-- El separador entre capítulo y opciones debe ser una línea única con tres guiones: ---
-
-=== FINALIZACIÓN ===
-- Si el capítulo actual coincide con el máximo configurado: genera un FINAL en lugar de un capítulo nuevo.
-- Si la modalidad de final es "sorpresa" o "cerrado", puedes terminar en un capítulo aleatorio, pero SIEMPRE generando un FINAL.
-
-=== PLAN INTERNO (NO IMPRIMIR) ===
-Antes de escribir, crea en tu mente un plan breve de 4–6 beats con: situación inicial, objetivo del protagonista, obstáculo, giro/complicación, decisión, consecuencia.
-No imprimas ese plan. Asegura causalidad clara entre beats.
-
-=== ECONOMÍA Y ESTILO ===
-- Apunta a un texto conciso, orientado a acción y detalles sensoriales relevantes (show, don’t tell).
-- Evita adjetivación redundante y perífrasis. Prefiere verbos precisos. Evita muletillas y repeticiones literales.
-- Mantén coherencia con lo ya escrito y con los géneros indicados.
-
-=== TWIST LÓGICO (CUANDO CORRESPONDA) ===
-- Si hay “final sorpresa”, el giro debe ser coherente con señales previas (foreshadowing). No uses “todo fue un sueño”.
-
-=== OPCIONES (CALIDAD) ===
-- Genera exactamente N opciones (provistas por el sistema/usuario).
-- Cada opción: 8–16 palabras; inicia con un verbo fuerte; incluye objetivo claro y costo/risgo o nueva información concreta; deben ser mutuamente excluyentes y alterar la dirección de la historia.
-- Prohibido: opciones vagas o duplicadas (“investigar más”, “seguir explorando”).
-
-=== ANTIRREPITICIÓN ===
-- No reutilices más de 6 palabras consecutivas del texto del usuario.
-- Cambia deliberadamente combinaciones ya usadas de {escenario, época, protagonista, dispositivo de misterio, tono} si el bloque [META] indica huellas recientes similares.
-- No repitas la misma oración inicial ni el mismo dispositivo de giro dos veces seguidas.
-
-=== BLOQUES AUXILIARES ===
-- Si aparece [META]...[/META] en el mensaje, úsalo como guía (p. ej., options_count, target_words, huellas recientes, clichés prohibidos), pero NO lo imprimas ni lo cites.
-- Respeta un objetivo de longitud si se indica (target_words ±10%).
-
-CUMPLE SIEMPRE el formato y todas estas reglas.`;
+export async function buildSystemPrompt(language: string): Promise<string> {
+  const { system } = await loadApiLocale(language);
+  return Object.values(system).join("\n");
+}
 
 export type BuildUserMessageArgs = {
   text: string;
@@ -47,23 +11,29 @@ export type BuildUserMessageArgs = {
   optionsCount: number;
   targetWords?: number;
   metaBlock?: string | null;
+  language: string;
+  genres?: string[];
 };
 
-export function buildUserMessage({
+export async function buildUserMessage({
   text,
   chosenOption,
   optionsCount,
   targetWords,
   metaBlock,
-}: BuildUserMessageArgs): string {
+  language,
+  genres,
+}: BuildUserMessageArgs): Promise<string> {
+  const locale = await loadApiLocale(language);
   const chosen = (chosenOption ?? "") + "";
-  const lines = [
-    text.trim(),
-    "",
-    `Opción elegida: ${chosen}`,
-    "",
-    `Genera exactamente ${optionsCount} opciones nuevas y coherentes para continuar la historia.`,
-  ];
+  const lines: string[] = [text.trim()];
+  if (genres && genres.length > 0 && locale.genreLine) {
+    lines.push("", locale.genreLine.replace("{genres}", genres.join(", ")));
+  }
+  const userLine = locale.user.continue
+    .replace("{option}", chosen)
+    .replace("{options}", optionsCount + "");
+  lines.push("", userLine);
   if (typeof targetWords === "number") {
     // Sugerencia suave al modelo; el SYSTEM dicta cómo usarlo vía [META].
   }


### PR DESCRIPTION
## Summary
- load API locale strings based on request language
- build system and user prompts with locale and genre line
- allow route to forward language to prompt builders

## Testing
- `npm run lint` *(fails: interactive ESLint config)*
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68ae1c09a8988329b3725a16ac7a8fa2