### PR TITLE
Handle case-insensitive final marker in story parsing

### DIFF
--- a/__tests__/parseStoryResponse.test.ts
+++ b/__tests__/parseStoryResponse.test.ts
@@ -22,4 +22,11 @@ describe('parseStoryResponse', () => {
       'Investigar las antiguas ruinas de la ciudad perdida',
     ]);
   });
+
+  it('detecta final ignorando mayúsculas y minúsculas', () => {
+    const text = 'El héroe ha cumplido su misión\nFiNaLiZaDo';
+    const { isFinal, options } = parseStoryResponse(text, 2);
+    expect(isFinal).toBe(true);
+    expect(options).toEqual([]);
+  });
 });

--- a/lib/parseStoryResponse.ts
+++ b/lib/parseStoryResponse.ts
@@ -22,8 +22,8 @@ export function parseStoryResponse(
 ): ParseResult {
   const raw = (text || '').trim();
 
-  // Detecta final por palabra EXACTA al final
-  const finalRegex = /FINALIZADO\s*$/;
+  // Detecta "finalizado" al final, ignorando mayúsculas y minúsculas
+  const finalRegex = /FINALIZADO\s*$/i;
   const isFinal = finalRegex.test(raw);
 
   let { story, optionsBlock } = splitStoryAndOptions(raw);


### PR DESCRIPTION
## Summary
- Make story completion detection case-insensitive
- Cover mixed-case "FiNaLiZaDo" with unit test

## Testing
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68ae351a386c8329a4b0c0ef250af2af