### PR TITLE
Validate API locale input and add fallback test

### DIFF
--- a/__tests__/apiLocale.test.ts
+++ b/__tests__/apiLocale.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment node
+ */
+import fs from 'fs/promises';
+import path from 'path';
+
+import { loadApiLocale } from '../lib/apiLocale';
+
+describe('loadApiLocale', () => {
+  it('falls back to neutral for invalid locale input', async () => {
+    const spy = jest.spyOn(fs, 'readFile');
+    const result = await loadApiLocale('../../etc/passwd');
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [filePath] = spy.mock.calls[0];
+    const neutralPath = path.join('public', 'locales', 'neutral', 'api.json');
+    expect(filePath).toContain(neutralPath);
+    expect(filePath).not.toMatch(/\.\./);
+    const neutral = await loadApiLocale('neutral');
+    expect(result).toEqual(neutral);
+    spy.mockRestore();
+  });
+});
+

--- a/lib/apiLocale.ts
+++ b/lib/apiLocale.ts
@@ -10,13 +10,23 @@ export type ApiLocale = {
 const cache = new Map<string, ApiLocale>();
 
 export async function loadApiLocale(language: string): Promise<ApiLocale> {
+  const localePattern = /^[A-Za-z0-9_-]+$/;
   const parts = typeof language === "string" ? language.split("-") : [];
-  const candidates = [language, parts[0], "neutral"].filter(Boolean) as string[];
+  const rawCandidates = [language, parts[0], "neutral"];
+  const candidates = rawCandidates.filter(
+    (loc): loc is string => !!loc && localePattern.test(loc)
+  );
   for (const loc of candidates) {
     if (cache.has(loc)) {
       return cache.get(loc)!;
     }
-    const file = path.join(process.cwd(), "public", "locales", loc, "api.json");
+    const file = path.join(
+      process.cwd(),
+      "public",
+      "locales",
+      loc,
+      "api.json"
+    );
     try {
       const data = await fs.readFile(file, "utf8");
       const json = JSON.parse(data) as ApiLocale;


### PR DESCRIPTION
## Summary
- validate requested API locale against a strict whitelist before building file paths
- add Jest test ensuring invalid locale inputs fall back to neutral and avoid path traversal

## Testing
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68ae351b70e883298d68f44828b803b5