### PR TITLE
refactor: clarify option limit handling

### DIFF
--- a/lib/optionGuard.ts
+++ b/lib/optionGuard.ts
@@ -56,7 +56,7 @@ export function dedupeOptions(options: string[]): string[] {
 
 export function validateOptions(
   options: string[],
-  N: number,
+  N: number, // number of options to return; should be a non-negative integer
   min = 2,
   max = 16
 ): { valid: string[]; discarded: OptionDiscard[] } {
@@ -72,7 +72,7 @@ export function validateOptions(
     }
   }
   return {
-    valid: valid.slice(0, Math.max(0, N | 0 || 0)),
+    valid: valid.slice(0, Math.max(0, Math.floor(N))),
     discarded,
   };
 }


### PR DESCRIPTION
## Summary
- replace bitwise N normalization with `Math.floor` in `validateOptions`
- document that N should be a non-negative integer

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npx jest`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68ae351d63e083298a5038b8fa36a2e5