### PR TITLE
feat: allow configuring Groq model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Example environment variables
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/thenoreal"
 GROQ_API_KEY="your-groq-api-key"
+GROQ_MODEL="meta-llama/llama-4-scout-17b-16e-instruct"
 NEXT_PUBLIC_SD_API="https://example.com/api/sd/generate"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Copy the example file and provide your own values:
 cp .env.example .env.local
 ```
 
-Set `GROQ_API_KEY` to a valid token from Groq (the previously committed key has been revoked) and update `DATABASE_URL` for your database. ` .env.local` is ignored by git and should not be committed.
+Set `GROQ_API_KEY` to a valid token from Groq (the previously committed key has been revoked) and update `DATABASE_URL` for your database. You can also set `GROQ_MODEL` to choose a Groq model; it defaults to `meta-llama/llama-4-scout-17b-16e-instruct`. `.env.local` is ignored by git and should not be committed.
 
 You can also define `NEXT_PUBLIC_IMAGE_TIMEOUT` (in milliseconds) to control how long the app waits for image generation before aborting and continuing without an image. It defaults to `15000`.
 

--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -50,7 +50,7 @@ export async function POST(req: Request) {
       { role: "user", content: userContent },
     ] as const;
 
-    const model = "meta-llama/llama-4-scout-17b-16e-instruct";//process.env.GROQ_MODEL || "moonshotai/kimi-k2-instruct";
+    const model = process.env.GROQ_MODEL ?? "meta-llama/llama-4-scout-17b-16e-instruct";
     const completion = await createChatCompletion({
       model,
       messages: messages as any,


### PR DESCRIPTION
## Summary
- allow overriding Groq model with `GROQ_MODEL` env var
- document `GROQ_MODEL` in README and `.env.example`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx jest`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4696ff8c8329b850966784530280