### PR TITLE
Clamp sampling parameters

### DIFF
--- a/app/api/options/route.ts
+++ b/app/api/options/route.ts
@@ -1,10 +1,13 @@
 import createChatCompletion from "@/lib/groqClient";
+import { limitTemperature, limitTopP } from "@/lib/sampling";
 
 const MAX_OPTIONS = 5;
 
 export async function POST(req: Request) {
   try {
     const { prompt, numOptions, temperature, top_p } = await req.json();
+    const safeTemperature = limitTemperature(temperature);
+    const safeTopP = limitTopP(top_p);
 
     const count = Number(numOptions) || 1;
     if (count > MAX_OPTIONS) {
@@ -23,8 +26,8 @@ export async function POST(req: Request) {
         model: "openai/gpt-oss-120b",
         messages: [{ role: "user", content: prompt }],
         n: 1,
-        temperature,
-        top_p,
+        temperature: safeTemperature,
+        top_p: safeTopP,
       });
 
       const option = completion.choices[0]?.message.content?.trim();

--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -4,6 +4,7 @@ import { buildSystemPrompt, buildUserMessage } from "@/lib/storyPrompt";
 import { buildMeta } from "@/lib/meta";
 import { computeFingerprint, pushFingerprint, getRecentFingerprints } from "@/lib/fingerprint";
 import { parseStoryResponse } from "@/lib/parseStoryResponse";
+import { limitTemperature, limitTopP } from "@/lib/sampling";
 
 export async function POST(req: Request) {
   if (!process.env.GROQ_API_KEY) {
@@ -17,8 +18,12 @@ export async function POST(req: Request) {
     const optionsCount: number = Number(body.optionsPerDecision ?? 2) || 2;
     const genres: string[] = Array.isArray(body.genres) ? body.genres : [];
     const language: string = typeof body.language === "string" ? body.language : "neutral";
-    const temperature: number = typeof body.ajustes?.temperature === "number" ? body.ajustes.temperature : 0.75;
-    const top_p: number = typeof body.ajustes?.top_p === "number" ? body.ajustes.top_p : 0.9;
+    const temperature: number | undefined = limitTemperature(
+      typeof body.ajustes?.temperature === "number" ? body.ajustes.temperature : 0.75,
+    );
+    const top_p: number | undefined = limitTopP(
+      typeof body.ajustes?.top_p === "number" ? body.ajustes.top_p : 0.9,
+    );
     const targetWords: number = typeof body.ajustes?.targetWords === "number" ? body.ajustes.targetWords : 220;
     // Define or import the Estilo type above if not already present
     type Estilo = any; // Replace 'any' with the actual structure if known

--- a/lib/sampling.ts
+++ b/lib/sampling.ts
@@ -1,0 +1,11 @@
+export function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+export function limitTemperature(temperature?: number): number | undefined {
+  return typeof temperature === "number" ? clamp01(temperature) : undefined;
+}
+
+export function limitTopP(top_p?: number): number | undefined {
+  return typeof top_p === "number" ? clamp01(top_p) : undefined;
+}


### PR DESCRIPTION
## Summary
- clamp `temperature` and `top_p` values between 0 and 1
- apply clamped sampling params in story and options endpoints

## Testing
- `npx jest`
- `npm run lint` *(fails: interactive config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4698d67883299ecddc0ca8197061