### PR TITLE
feat: validate generated options

### DIFF
--- a/app/api/options/route.ts
+++ b/app/api/options/route.ts
@@ -1,4 +1,5 @@
 import createChatCompletion from "@/lib/groqClient";
+import { validateOptions, OptionDiscard } from "@/lib/optionGuard";
 
 const MAX_OPTIONS = 5;
 
@@ -14,10 +15,12 @@ export async function POST(req: Request) {
       );
     }
 
-    const options: string[] = [];
+    const rawOptions: string[] = [];
+    let validOptions: string[] = [];
+    let discarded: OptionDiscard[] = [];
     let attempts = 0;
     const maxAttempts = count + 2;
-    while (options.length < count && attempts < maxAttempts) {
+    while (validOptions.length < count && attempts < maxAttempts) {
       attempts++;
       const completion = await createChatCompletion({
         model: "openai/gpt-oss-120b",
@@ -29,37 +32,36 @@ export async function POST(req: Request) {
 
       const option = completion.choices[0]?.message.content?.trim();
       if (option) {
-        options.push(option);
+        rawOptions.push(option);
+        ({ valid: validOptions, discarded } = validateOptions(rawOptions, count));
       }
       console.log("options progress", {
         expected: count,
-        received: options.length,
+        received: validOptions.length,
         attempts,
       });
     }
 
-    const uniqueOptions = Array.from(new Set(options.map((o) => o.trim()))).filter(
-      Boolean,
-    );
-
-    if (uniqueOptions.length < count) {
-      console.warn("Fewer options generated than requested", {
+    if (validOptions.length < count) {
+      console.warn("Fewer valid options generated than requested", {
         expected: count,
-        received: uniqueOptions.length,
+        received: validOptions.length,
         attempts,
+        discarded,
       });
       return Response.json(
         {
-          error: `Generated ${uniqueOptions.length} of ${count} options`,
-          options: uniqueOptions,
+          error: `Generated ${validOptions.length} of ${count} options`,
+          options: validOptions,
+          discarded,
         },
         { status: 502 },
       );
     }
 
-    console.log("Groq options response", uniqueOptions);
+    console.log("Groq options response", validOptions);
 
-    return Response.json({ options: uniqueOptions });
+    return Response.json({ options: validOptions });
   } catch (err) {
     console.error(err);
     return Response.json({ error: "Error generating options" }, { status: 500 });


### PR DESCRIPTION
## Summary
- use validateOptions to ensure API option responses meet criteria
- regenerate and discard invalid choices until enough valid options are collected

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68ae46991aac8329a510a4297dfe3c16