### PR TITLE
refactor: tighten types for story generation

### DIFF
--- a/app/api/story/route.ts
+++ b/app/api/story/route.ts
@@ -4,6 +4,8 @@ import { buildSystemPrompt, buildUserMessage } from "@/lib/storyPrompt";
 import { buildMeta } from "@/lib/meta";
 import { computeFingerprint, pushFingerprint, getRecentFingerprints } from "@/lib/fingerprint";
 import { parseStoryResponse } from "@/lib/parseStoryResponse";
+import type { Estilo } from "@/types/story";
+import type { ChatCompletionMessageParam } from "groq-sdk/resources/chat/completions";
 
 export async function POST(req: Request) {
   if (!process.env.GROQ_API_KEY) {
@@ -11,19 +13,25 @@ export async function POST(req: Request) {
   }
 
   try {
-    const body = await req.json();
-    const storyText: string = body.story ?? "";
-    const chosenOption: string = body.option ?? "";
-    const optionsCount: number = Number(body.optionsPerDecision ?? 2) || 2;
-    const genres: string[] = Array.isArray(body.genres) ? body.genres : [];
-    const language: string = typeof body.language === "string" ? body.language : "neutral";
-    const temperature: number = typeof body.ajustes?.temperature === "number" ? body.ajustes.temperature : 0.75;
-    const top_p: number = typeof body.ajustes?.top_p === "number" ? body.ajustes.top_p : 0.9;
-    const targetWords: number = typeof body.ajustes?.targetWords === "number" ? body.ajustes.targetWords : 220;
-    // Define or import the Estilo type above if not already present
-    type Estilo = any; // Replace 'any' with the actual structure if known
-    
-        const estilo: Estilo | undefined = body.estilo;
+    const body: {
+      story?: string;
+      option?: string;
+      optionsPerDecision?: number;
+      genres?: string[];
+      language?: string;
+      ajustes?: { temperature?: number; top_p?: number; targetWords?: number };
+      estilo?: Estilo;
+    } = await req.json();
+
+    const storyText = body.story ?? "";
+    const chosenOption = body.option ?? "";
+    const optionsCount = Number(body.optionsPerDecision ?? 2) || 2;
+    const genres = Array.isArray(body.genres) ? body.genres : [];
+    const language = typeof body.language === "string" ? body.language : "neutral";
+    const temperature = typeof body.ajustes?.temperature === "number" ? body.ajustes.temperature : 0.75;
+    const top_p = typeof body.ajustes?.top_p === "number" ? body.ajustes.top_p : 0.9;
+    const targetWords = typeof body.ajustes?.targetWords === "number" ? body.ajustes.targetWords : 220;
+    const estilo: Estilo | undefined = body.estilo;
 
     const metaBlock = buildMeta({
       optionsCount,
@@ -45,15 +53,15 @@ export async function POST(req: Request) {
       }),
     ]);
 
-    const messages = [
+    const messages: ChatCompletionMessageParam[] = [
       { role: "system", content: systemContent },
       { role: "user", content: userContent },
-    ] as const;
+    ];
 
     const model = "meta-llama/llama-4-scout-17b-16e-instruct";//process.env.GROQ_MODEL || "moonshotai/kimi-k2-instruct";
     const completion = await createChatCompletion({
       model,
-      messages: messages as any,
+      messages,
       temperature,
       top_p,
     });
@@ -78,7 +86,7 @@ export async function POST(req: Request) {
 
     // Devolvemos datos estructurados en lugar del texto sin procesar
     return NextResponse.json({ story, options, isFinal });
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("api/story error:", err);
     return NextResponse.json({ error: "Error al procesar la solicitud" }, { status: 500 });
   }

--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -4,11 +4,8 @@ import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { useLanguage } from "../providers/LanguageProvider";
 import Story from "./Story";
-import StorySettings, {
-  ConfigGeneracion,
-  ESTILO_SECTIONS,
-  AJUSTES_SECTIONS,
-} from "./StorySettings";
+import StorySettings, { ESTILO_SECTIONS, AJUSTES_SECTIONS } from "./StorySettings";
+import type { ConfigGeneracion, Genero, Ajustes } from "@/types/story";
 
 type EndingMode =
   | "capitulos"
@@ -33,9 +30,9 @@ const GENRES = [
   "Misterio",
   "Romance",
   "Comedia",
-] as const;
+] as const satisfies readonly Genero[];
 
-const GENRE_ICONS: Record<string, string> = {
+const GENRE_ICONS: Record<Genero, string> = {
   Aventura: "/icons/aventura.svg",
   "Ciencia ficción": "/icons/ciencia-ficcion.svg",
   Terror: "/icons/terror.svg",
@@ -54,8 +51,6 @@ function countTokens(text: string) {
 function randomPick<T>(arr: T[]): T {
   return arr[Math.floor(Math.random() * arr.length)];
 }
-const toArray = <T,>(v: T | T[] | undefined | null): T[] =>
-  Array.isArray(v) ? v : v == null ? [] : [v];
 const isNonEmptyArray = (v: unknown): v is unknown[] =>
   Array.isArray(v) && v.length > 0;
 const clamp = (n: number, min: number, max: number) =>
@@ -63,14 +58,39 @@ const clamp = (n: number, min: number, max: number) =>
 const normalizeLocale = (loc: string) =>
   (loc || "es").toLowerCase().split("-")[0];
 
+type AjustesPayload = Omit<Ajustes, "creatividad" | "topP"> & {
+  temperature: number;
+  top_p: number;
+  targetWords: number;
+};
+
 const defaults: ConfigGeneracion = {
   generos: [],
-  estilo: { tono: [], ritmo: [], voz: [], tiempo: [], formato: [], descripcion: [], dialogo: [], matiz: [] },
+  estilo: {
+    tono: [],
+    ritmo: [],
+    voz: [],
+    tiempo: [],
+    formato: [],
+    descripcion: [],
+    dialogo: [],
+    matiz: [],
+  },
   ajustes: {
-    publico: [], epoca: [], ambito: [], estructura: [], incluir: [], evitar: [], clasificacion: [], idioma: [], registro: [],
-    creatividad: 0.75, topP: 0.9, opcionesPorCapitulo: [],
+    publico: [],
+    epoca: [],
+    ambito: [],
+    estructura: [],
+    incluir: [],
+    evitar: [],
+    clasificacion: [],
+    idioma: [],
+    registro: [],
+    creatividad: 0.75,
+    topP: 0.9,
+    opcionesPorCapitulo: [],
     targetWords: 220,
-  } as any,
+  },
 };
 
 export default function StoryForm() {
@@ -104,7 +124,7 @@ export default function StoryForm() {
 
   const showChapters = modality === "capitulos" || modality === "final_sorpresa";
 
-  const toggleGenre = (genre: string) => {
+  const toggleGenre = (genre: Genero) => {
     setConfig((prev) => ({
       ...prev,
       generos: prev.generos.includes(genre)
@@ -117,13 +137,26 @@ export default function StoryForm() {
 
   const randomizeConfig = () => {
     const genero = randomPick([...GENRES]);
-    const estilo = ESTILO_SECTIONS.reduce(
-      (acc, { key, options }) => { acc[key] = [randomPick(options)]; return acc; },
-      {} as ConfigGeneracion["estilo"]
+    const estilo = ESTILO_SECTIONS.reduce<ConfigGeneracion["estilo"]>(
+      (acc, { key, options }) => ({ ...acc, [key]: [randomPick(options)] }),
+      { tono: [], ritmo: [], voz: [], tiempo: [], formato: [], descripcion: [], dialogo: [], matiz: [] }
     );
-    const ajustes = AJUSTES_SECTIONS.reduce(
-      (acc, { key, options }) => { (acc as any)[key] = [randomPick(options)]; return acc; },
-      {} as ConfigGeneracion["ajustes"]
+    const ajustesBase: ConfigGeneracion["ajustes"] = {
+      ...defaults.ajustes,
+      publico: [],
+      epoca: [],
+      ambito: [],
+      estructura: [],
+      clasificacion: [],
+      idioma: [],
+      registro: [],
+      opcionesPorCapitulo: [],
+      incluir: [],
+      evitar: [],
+    };
+    const ajustes = AJUSTES_SECTIONS.reduce<ConfigGeneracion["ajustes"]>(
+      (acc, { key, options }) => ({ ...acc, [key]: [randomPick(options)] }),
+      ajustesBase
     );
     setConfig({ generos: [genero], estilo, ajustes });
   };
@@ -161,12 +194,12 @@ export default function StoryForm() {
 
       const final: EndingMode = modality;
 
-      const { creatividad, topP, ...restAjustes } = config.ajustes as any;
-      const ajustesPayload: any = {
+      const { creatividad = 0.75, topP = 0.9, targetWords: _tw, ...restAjustes } = config.ajustes;
+      const ajustesPayload: AjustesPayload = {
         ...restAjustes,
-        temperature: typeof creatividad === "number" ? creatividad : 0.75,
-        top_p: typeof topP === "number" ? topP : 0.9,
-        targetWords: targetWords,
+        temperature: creatividad,
+        top_p: topP,
+        targetWords,
       };
 
       const lang = normalizeLocale(locale);
@@ -187,16 +220,14 @@ export default function StoryForm() {
         }),
       });
 
-      const data = await response.json().catch(() => ({}));
+      const data: { story?: string; options?: string[]; error?: string } = await response
+        .json()
+        .catch(() => ({}));
 
       if (!response.ok) {
-        setError((data as { error?: string }).error || "Error al obtener la historia inicial");
+        setError(data.error || "Error al obtener la historia inicial");
       } else {
-        const {
-          story = "",
-          options = [],
-        } = data as { story?: string; options?: string[] };
-
+        const { story = "", options = [] } = data;
         let opts = Array.from(new Set(options.filter(Boolean)));
 
         if (opts.length < optionsPerDecision) {
@@ -212,14 +243,18 @@ export default function StoryForm() {
                 top_p: ajustesPayload.top_p,
               }),
             });
-            const optData = await optRes.json().catch(() => ({}));
-            if (optRes.ok && Array.isArray((optData as any).options)) {
+            const optData: { options?: unknown[]; error?: string } = await optRes
+              .json()
+              .catch(() => ({}));
+            if (optRes.ok && Array.isArray(optData.options)) {
               const extra = Array.from(
-                new Set(((optData as any).options as string[]).filter(Boolean))
+                new Set(
+                  optData.options.filter((o): o is string => typeof o === "string" && o.length > 0)
+                )
               );
               opts = Array.from(new Set([...opts, ...extra]));
             } else {
-              setError((optData as { error?: string }).error || "Error al obtener opciones adicionales");
+              setError(optData.error || "Error al obtener opciones adicionales");
             }
           } catch {
             setError("Error al obtener opciones adicionales");
@@ -276,20 +311,22 @@ export default function StoryForm() {
           <div className="w-full max-w-xl rounded-lg border border-black/30 p-4">
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
               {GENRES.map((genre) => {
-                const selected = config.generos.includes(genre as any);
+                const selected = config.generos.includes(genre);
                 return (
                   <button
-                    key={genre as any}
+                    key={genre}
                     type="button"
                     aria-pressed={selected ? "true" : "false"}
-                    onClick={() => toggleGenre(genre as any)}
+                    onClick={() => toggleGenre(genre)}
                     title={selected ? "Quitar género" : "Agregar género"}
                     className={`flex items-center gap-2 px-3 py-2 rounded-xl border transition ${
-                      selected ? "bg-accent text-black border-black/40 shadow-inner"
-                              : "bg-white/40 hover:bg-white/70 border-black/20 hover:border-black/40"}`}
+                      selected
+                        ? "bg-accent text-black border-black/40 shadow-inner"
+                        : "bg-white/40 hover:bg-white/70 border-black/20 hover:border-black/40"
+                    }`}
                   >
-                    <img src={GENRE_ICONS[genre as any] ?? "/icons/generico.svg"} alt="" className="w-6 h-6" />
-                    <span className="truncate">{genre as any}</span>
+                    <img src={GENRE_ICONS[genre] ?? "/icons/generico.svg"} alt="" className="w-6 h-6" />
+                    <span className="truncate">{genre}</span>
                     {selected && (
                       <span className="ml-auto inline-flex h-5 w-5 items-center justify-center rounded-full border border-black/30">
                         ✓
@@ -334,7 +371,7 @@ export default function StoryForm() {
                     <button
                       key={`chip-${genre}`}
                       type="button"
-                      onClick={() => toggleGenre(genre as any)}
+                      onClick={() => toggleGenre(genre)}
                       className="inline-flex items-center gap-2 rounded-full border border-black/30 bg-accent/90 px-3 py-1 text-sm text-black hover:bg-accent"
                       title="Quitar"
                     >
@@ -433,16 +470,34 @@ export default function StoryForm() {
                 <span key={`genero-${genre}`} className="px-2 py-1 text-sm rounded-full bg-accent text-black">{genre}</span>
               ))}
 
-              {Object.entries(config.estilo).flatMap(([key, values]) =>
-                toArray(values as string[]).map((v) => (
-                  <span key={`estilo-${key}-${v}`} className="px-2 py-1 text-sm rounded-full bg-accent text-black">{v}</span>
-                )),
+              {(Object.entries(config.estilo) as Array<[
+                keyof ConfigGeneracion["estilo"],
+                string[]
+              ]>).flatMap(([key, values]) =>
+                values.map((v) => (
+                  <span
+                    key={`estilo-${String(key)}-${v}`}
+                    className="px-2 py-1 text-sm rounded-full bg-accent text-black"
+                  >
+                    {v}
+                  </span>
+                ))
               )}
 
-              {Object.entries(config.ajustes).flatMap(([key, values]) =>
-                toArray(values as string[]).map((v) => (
-                  <span key={`ajuste-${key}-${v}`} className="px-2 py-1 text-sm rounded-full bg-accent text-black">{v}</span>
-                )),
+              {(Object.entries(config.ajustes) as Array<[
+                string,
+                unknown
+              ]>).flatMap(([key, value]) =>
+                Array.isArray(value)
+                  ? value.map((v: string) => (
+                      <span
+                        key={`ajuste-${key}-${v}`}
+                        className="px-2 py-1 text-sm rounded-full bg-accent text-black"
+                      >
+                        {v}
+                      </span>
+                    ))
+                  : []
               )}
             </div>
           )}
@@ -458,7 +513,7 @@ export default function StoryForm() {
           chaptersCount={storyConfig.chaptersCount}
           genres={config.generos}
           estilo={config.estilo}
-          ajustes={config.ajustes as any}
+          ajustes={config.ajustes}
           onBack={resetStory}
         />
       )}
@@ -476,24 +531,43 @@ export default function StoryForm() {
         config={config}
         onClose={() => setOpen(false)}
         onSave={(cfg) => {
+          const ajustesCfg = cfg.ajustes as Ajustes;
           const normalized: ConfigGeneracion = {
-            generos: Array.isArray(cfg.generos) ? cfg.generos : [],
+            generos: Array.isArray(cfg.generos) ? (cfg.generos as Genero[]) : [],
             estilo: {
-              tono: cfg.estilo.tono ?? [], ritmo: cfg.estilo.ritmo ?? [], voz: cfg.estilo.voz ?? [], tiempo: cfg.estilo.tiempo ?? [],
-              formato: cfg.estilo.formato ?? [], descripcion: cfg.estilo.descripcion ?? [], dialogo: cfg.estilo.dialogo ?? [], matiz: cfg.estilo.matiz ?? [],
+              tono: cfg.estilo.tono ?? [],
+              ritmo: cfg.estilo.ritmo ?? [],
+              voz: cfg.estilo.voz ?? [],
+              tiempo: cfg.estilo.tiempo ?? [],
+              formato: cfg.estilo.formato ?? [],
+              descripcion: cfg.estilo.descripcion ?? [],
+              dialogo: cfg.estilo.dialogo ?? [],
+              matiz: cfg.estilo.matiz ?? [],
             },
             ajustes: {
-              publico: cfg.ajustes.publico ?? [], epoca: cfg.ajustes.epoca ?? [], ambito: cfg.ajustes.ambito ?? [], estructura: cfg.ajustes.estructura ?? [],
-              incluir: cfg.ajustes.incluir ?? [], evitar: cfg.ajustes.evitar ?? [], clasificacion: cfg.ajustes.clasificacion ?? [], idioma: cfg.ajustes.idioma ?? [],
-              registro: cfg.ajustes.registro ?? [], opcionesPorCapitulo: cfg.ajustes.opcionesPorCapitulo ?? [],
-              lugar: cfg.ajustes.lugar, longitudPalabras: cfg.ajustes.longitudPalabras, creatividad: cfg.ajustes.creatividad,
-              topP: cfg.ajustes.topP, semilla: cfg.ajustes.semilla, consistenciaSaga: cfg.ajustes.consistenciaSaga,
-              estiloVisual: cfg.ajustes.estiloVisual, paleta: cfg.ajustes.paleta,
-              targetWords: (cfg as any).ajustes?.targetWords ?? 220,
-            } as any,
+              publico: cfg.ajustes.publico ?? [],
+              epoca: cfg.ajustes.epoca ?? [],
+              ambito: cfg.ajustes.ambito ?? [],
+              estructura: cfg.ajustes.estructura ?? [],
+              incluir: cfg.ajustes.incluir ?? [],
+              evitar: cfg.ajustes.evitar ?? [],
+              clasificacion: cfg.ajustes.clasificacion ?? [],
+              idioma: cfg.ajustes.idioma ?? [],
+              registro: cfg.ajustes.registro ?? [],
+              opcionesPorCapitulo: cfg.ajustes.opcionesPorCapitulo ?? [],
+              lugar: cfg.ajustes.lugar,
+              longitudPalabras: cfg.ajustes.longitudPalabras,
+              creatividad: cfg.ajustes.creatividad,
+              topP: cfg.ajustes.topP,
+              semilla: cfg.ajustes.semilla,
+              consistenciaSaga: cfg.ajustes.consistenciaSaga,
+              estiloVisual: cfg.ajustes.estiloVisual,
+              paleta: cfg.ajustes.paleta,
+              targetWords: ajustesCfg.targetWords ?? 220,
+            },
           };
           setConfig(normalized);
-          setTargetWords((normalized.ajustes as any).targetWords ?? 220);
+          setTargetWords(normalized.ajustes.targetWords ?? 220);
           setOpen(false);
         }}
       />

--- a/types/story.ts
+++ b/types/story.ts
@@ -7,6 +7,10 @@ export type Genero =
   | 'Romance'
   | 'Comedia';
 
+/**
+ * Preferencias estilísticas para la historia.
+ * Cada propiedad es una lista de etiquetas seleccionadas por el usuario.
+ */
 export interface Estilo {
   tono: string[];
   ritmo: string[];
@@ -18,6 +22,11 @@ export interface Estilo {
   matiz: string[];
 }
 
+/**
+ * Ajustes que controlan la generación de la historia.  Los campos de tipo
+ * `string[]` representan listas de opciones elegidas por el usuario y los
+ * numéricos modifican el comportamiento del modelo.
+ */
 export interface Ajustes {
   publico: string[];
   epoca: string[];
@@ -37,6 +46,8 @@ export interface Ajustes {
   consistenciaSaga?: boolean;
   estiloVisual?: string;
   paleta?: string;
+  /** Número objetivo de palabras por capítulo */
+  targetWords?: number;
 }
 
 export interface ConfigGeneracion {


### PR DESCRIPTION
## Summary
- document Estilo and Ajustes structure
- replace `any` usage in API route with typed request parsing
- use strict ConfigGeneracion types in StoryForm

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot use namespace 'jest' as a value)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4699b314832983f47768127e632a