### PR TITLE
refactor: centralize Fingerprint type

### DIFF
--- a/lib/fingerprint.ts
+++ b/lib/fingerprint.ts
@@ -1,11 +1,5 @@
-export type Fingerprint = {
-  escenario: string;
-  epoca: string;
-  protagonista: string;
-  dispositivo: string;
-  tono: string;
-  firstSentence: string;
-};
+import type { Fingerprint } from "../types/fingerprint";
+export type { Fingerprint };
 
 type GlobalWithRing = typeof globalThis & {
   __fingerprints?: Fingerprint[];

--- a/lib/meta.ts
+++ b/lib/meta.ts
@@ -1,11 +1,5 @@
-export type Fingerprint = {
-  escenario: string;
-  epoca: string;
-  protagonista: string;
-  dispositivo: string;
-  tono: string;
-  firstSentence?: string;
-};
+import type { Fingerprint } from "../types/fingerprint";
+export type { Fingerprint };
 
 export function buildMeta({
   optionsCount,

--- a/types/fingerprint.ts
+++ b/types/fingerprint.ts
@@ -1,0 +1,8 @@
+export type Fingerprint = {
+  escenario: string;
+  epoca: string;
+  protagonista: string;
+  dispositivo: string;
+  tono: string;
+  firstSentence?: string;
+};


### PR DESCRIPTION
## Summary
- move Fingerprint type into `types/fingerprint.ts`
- update `lib/fingerprint` and `lib/meta` to import the shared type

## Testing
- `npx jest`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ae469ca45883298df9b5569a664dac