### PR TITLE
Import sampling limits in options route

### DIFF
--- a/app/api/options/route.ts
+++ b/app/api/options/route.ts
@@ -1,5 +1,6 @@
 import createChatCompletion from "@/lib/groqClient";
 import { validateOptions, OptionDiscard } from "@/lib/optionGuard";
+import { limitTemperature, limitTopP } from "@/lib/sampling";
 
 const MAX_OPTIONS = 5;
 


### PR DESCRIPTION
## Summary
- Import `limitTemperature` and `limitTopP` from sampling utilities in options API route.
- Ensure `safeTemperature` and `safeTopP` use the imported helpers.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68ae54667d408329a852723ed88be546