### PR TITLE
Escape Groq API key in filterSensitive

### DIFF
--- a/__tests__/groqClient.test.ts
+++ b/__tests__/groqClient.test.ts
@@ -1,0 +1,22 @@
+jest.mock('groq-sdk', () => ({
+  __esModule: true,
+  default: class {
+    chat = { completions: { create: jest.fn() } };
+  },
+}));
+
+import { filterSensitive } from '../lib/groqClient';
+
+describe('filterSensitive', () => {
+  afterEach(() => {
+    delete process.env.GROQ_API_KEY;
+  });
+
+  it('redacts secrets containing special regex characters', () => {
+    const secret = 'ab.*+?^${}()|[]\\c';
+    process.env.GROQ_API_KEY = secret;
+    const input = `before${secret}after`;
+    const result = filterSensitive(input) as string;
+    expect(result).toBe('before[REDACTED]after');
+  });
+});

--- a/lib/groqClient.ts
+++ b/lib/groqClient.ts
@@ -7,11 +7,12 @@ import type { Stream } from 'groq-sdk/lib/streaming';
 
 const groq = new Groq({ apiKey: process.env.GROQ_API_KEY });
 
-function filterSensitive(data: unknown): unknown {
+export function filterSensitive(data: unknown): unknown {
   const secret = process.env.GROQ_API_KEY;
   if (!secret) return data;
+  const escapedSecret = secret.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   if (typeof data === 'string') {
-    return data.replace(new RegExp(secret, 'g'), '[REDACTED]');
+    return data.replace(new RegExp(escapedSecret, 'g'), '[REDACTED]');
   }
   if (Array.isArray(data)) {
     return data.map(filterSensitive);


### PR DESCRIPTION
## Summary
- escape the Groq API key before building the redaction RegExp
- export `filterSensitive` and test redaction with secrets containing regex characters

## Testing
- `npx jest __tests__/groqClient.test.ts`
- `npx jest` *(fails: optionGuard.test.ts, parseStoryResponse.test.ts, storyFormMissingOptions.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5b290bdc8329bffbfde8df312748