### PR TITLE
feat: add infinite and undefined ending options

### DIFF
--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -18,6 +18,8 @@ const MODALITY_HELP = {
   final_sorpresa: "Añade un giro inesperado al final.",
   final_abierto: "La historia queda abierta a interpretación.",
   final_cerrado: "La historia tiene un desenlace definido.",
+  sin_final_definido: "La historia no tiene un final predeterminado.",
+  infinita: "La historia continúa indefinidamente.",
 } as const;
 
 type Modality = keyof typeof MODALITY_HELP;
@@ -160,6 +162,10 @@ export default function StoryForm() {
         switch (modality) {
           case "final_abierto": return "sin_final_definido";
           case "final_cerrado": return chaptersNum ? "capitulos" : "sin_final_definido";
+          case "sin_final_definido":
+          case "infinita":
+          case "capitulos":
+          case "final_sorpresa":
           default: return modality;
         }
       })();
@@ -356,6 +362,8 @@ export default function StoryForm() {
                 <option value="final_sorpresa">Final sorpresa</option>
                 <option value="final_abierto">Final abierto</option>
                 <option value="final_cerrado">Final cerrado</option>
+                <option value="sin_final_definido">Sin final definido</option>
+                <option value="infinita">Historia infinita</option>
               </select>
             </div>
 


### PR DESCRIPTION
## Summary
- expose `sin_final_definido` and `infinita` options in story creation form
- map new modalities directly to their corresponding ending modes

## Testing
- `npm run build` *(fails: Environment variable not found: DATABASE_URL_UNPOOLED)*
- `npx jest` *(fails: 3 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5b2bdb08832985e7e2dec262cff9