### PR TITLE
feat: add strict story parser

### DIFF
--- a/__tests__/parseStoryResponse.test.ts
+++ b/__tests__/parseStoryResponse.test.ts
@@ -1,4 +1,4 @@
-import { parseStoryResponse } from '../lib/parseStoryResponse';
+import { parseStoryResponse, parseStoryResponseStrict } from '../lib/parseStoryResponse';
 
 describe('parseStoryResponse', () => {
   it('separates historia y opciones con ---', () => {
@@ -23,10 +23,18 @@ describe('parseStoryResponse', () => {
     ]);
   });
 
-  it('detecta final ignorando mayúsculas y minúsculas', () => {
-    const text = 'El héroe ha cumplido su misión\nFiNaLiZaDo';
+  it('detecta final solo con FINALIZADO exacto', () => {
+    const text = 'El héroe ha cumplido su misión\nFINALIZADO';
     const { isFinal, options } = parseStoryResponse(text, 2);
     expect(isFinal).toBe(true);
     expect(options).toEqual([]);
+  });
+});
+
+describe('parseStoryResponseStrict', () => {
+  it('emite error cuando falta separador', () => {
+    const text = 'Historia sin separador\n1. Opción inválida';
+    const result = parseStoryResponseStrict(text, 1);
+    expect(result.errors).toContain('missing options separator');
   });
 });

--- a/lib/parseStoryResponse.ts
+++ b/lib/parseStoryResponse.ts
@@ -1,43 +1,147 @@
-import { validateOptions } from "./optionGuard";
-
 export type ParseResult = {
   story: string;
   options: string[];
   isFinal: boolean;
 };
 
-// Split exacto por línea '---'.
-function splitStoryAndOptions(text: string): { story: string; optionsBlock: string | null } {
-  const lines = (text || "").split(/\r?\n/);
-  const idx = lines.findIndex(l => l.trim() === "---");
-  if (idx === -1) return { story: text.trim(), optionsBlock: null };
-  const story = lines.slice(0, idx).join("\n").trim();
-  const optionsBlock = lines.slice(idx + 1).join("\n");
-  return { story, optionsBlock };
+export type ParseResultStrict = ParseResult & {
+  errors: string[];
+  diagnostics: string[];
+};
+
+function countWords(s: string): number {
+  const m = s.match(/[\p{L}\p{N}]+/gu);
+  return m ? m.length : 0;
 }
 
-export function parseStoryResponse(text: string, optionsPerDecision: number): ParseResult {
-  const raw = (text || "").trim();
+function normalizeRaw(raw: string): { text: string; trailingBlankLines: boolean } {
+  const replaced = (raw || "").replace(/\r\n?/g, "\n");
+  const trailingBlankLines = /\n\s*$/.test(replaced);
+  return { text: replaced.trimEnd(), trailingBlankLines };
+}
 
-  // Detecta final por palabra EXACTA al final
-  const finalRegex = /FINALIZADO\s*$/i;
-  const isFinal = finalRegex.test(raw);
+function splitStoryAndOptionsNormalized(
+  text: string,
+): {
+  story: string;
+  optionsBlock: string | null;
+  separatorLine: string | null;
+} {
+  const lines = text.split("\n");
+  const idx = lines.findIndex(l => l.trim() === "---");
+  if (idx === -1) return { story: text.trim(), optionsBlock: null, separatorLine: null };
+  const story = lines.slice(0, idx).join("\n").trimEnd();
+  const optionsBlock = lines.slice(idx + 1).join("\n").trimEnd();
+  return { story, optionsBlock, separatorLine: lines[idx] };
+}
 
-  const { story, optionsBlock } = splitStoryAndOptions(raw);
-  let options: string[] = [];
+function extractOptions(block: string): {
+  options: string[];
+  diagnostics: string[];
+} {
+  const lines = block.split("\n");
+  const options: string[] = [];
+  const diagnostics: string[] = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const numbered = line.match(/^\s*\d+\.\s+(.*)$/);
+    if (numbered) {
+      options.push(numbered[1].trim());
+      continue;
+    }
+    if (/^\s*[-*]/.test(line)) {
+      diagnostics.push("option line uses markdown bullet");
+    } else {
+      diagnostics.push("unrecognized option line");
+    }
+  }
+  return { options, diagnostics };
+}
 
-  if (!isFinal && optionsBlock) {
-    const optLines = optionsBlock.split(/\r?\n/);
-    const parsed = optLines
-      .map(l => {
-        const m = l.match(/^\s*\d+\.\s+(.+?)\s*$/);
-        return m ? m[1] : null;
-      })
-      .filter(Boolean) as string[];
+export function parseStoryResponseStrict(
+  raw: string,
+  optionsPerDecision: number,
+  optionMinWords?: number,
+  optionMaxWords?: number,
+): ParseResultStrict {
+  const errors: string[] = [];
+  const diagnostics: string[] = [];
 
-    const { valid } = validateOptions(parsed, optionsPerDecision);
-    options = valid;
+  const { text: normalized, trailingBlankLines } = normalizeRaw(raw);
+  if (trailingBlankLines) diagnostics.push("trailing blank lines");
+  if (/`{3}|^\s*[-*#]/m.test(normalized)) diagnostics.push("markdown hints");
+
+  const isFinal = /(?:^|\n)FINALIZADO$/.test(normalized);
+  let working = normalized;
+  if (isFinal) {
+    working = working.replace(/(?:^|\n)FINALIZADO$/, "").trimEnd();
   }
 
+  const { story, optionsBlock, separatorLine } = splitStoryAndOptionsNormalized(working);
+
+  let options: string[] = [];
+  if (!isFinal && optionsPerDecision > 0) {
+    if (!optionsBlock) {
+      errors.push("missing options separator");
+    } else {
+      if (separatorLine !== "---") {
+        errors.push("separator must be --- on its own line");
+      }
+      const { options: extracted, diagnostics: optDiag } = extractOptions(optionsBlock);
+      options = extracted;
+      diagnostics.push(...optDiag);
+      if (options.length !== optionsPerDecision) {
+        errors.push(`expected ${optionsPerDecision} options but got ${options.length}`);
+      }
+      if (optionMinWords !== undefined || optionMaxWords !== undefined) {
+        const min = optionMinWords ?? 0;
+        const max = optionMaxWords ?? Infinity;
+        options.forEach((opt, i) => {
+          const words = countWords(opt);
+          if (optionMinWords !== undefined && words < min) {
+            errors.push(`option ${i + 1} has fewer than ${min} words`);
+          }
+          if (optionMaxWords !== undefined && words > max) {
+            errors.push(`option ${i + 1} has more than ${max} words`);
+          }
+        });
+      }
+    }
+  } else if (isFinal && optionsBlock) {
+    errors.push("final response should not contain separator");
+  }
+
+  return {
+    story: story.trim(),
+    options: options.map(o => o.trim()),
+    isFinal,
+    errors,
+    diagnostics,
+  };
+}
+
+export function parseStoryResponse(
+  text: string,
+  optionsPerDecision: number,
+): ParseResult;
+export function parseStoryResponse(
+  text: string,
+  optionsPerDecision: number,
+  optionMinWords?: number,
+  optionMaxWords?: number,
+): ParseResult;
+export function parseStoryResponse(
+  text: string,
+  optionsPerDecision: number,
+  optionMinWords?: number,
+  optionMaxWords?: number,
+): ParseResult {
+  const { story, options, isFinal } = parseStoryResponseStrict(
+    text,
+    optionsPerDecision,
+    optionMinWords,
+    optionMaxWords,
+  );
   return { story, options, isFinal };
 }
+


### PR DESCRIPTION
## Summary
- add `parseStoryResponseStrict` with detailed errors and diagnostics
- tighten FINALIZADO handling and option parsing
- update tests for new parser behavior

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68b12d50d9cc83298cf0dc75ef78990b