### PR TITLE
Simplify option validation logic

### DIFF
--- a/__tests__/optionGuard.test.ts
+++ b/__tests__/optionGuard.test.ts
@@ -1,43 +1,24 @@
 import { validateOptions } from '../lib/optionGuard';
 
 describe('validateOptions', () => {
-  it('provides reason for discarded options', () => {
-    const { valid, discarded } = validateOptions(
-      ['Correr', 'Ir al parque con mis amigos en la mañana'],
-      2,
-    );
-    expect(valid).toEqual(['Ir al parque con mis amigos en la mañana']);
-    expect(discarded).toEqual([
-      expect.objectContaining({ option: 'Correr' }),
-    ]);
-    expect(discarded[0].reason).toMatch(/menos de/);
-  });
-
-  it('allows shorter options when lowering min', () => {
-    const { valid } = validateOptions(['Regresar'], 1, 1);
-    expect(valid).toEqual(['Regresar']);
-  });
-
-  it('allows longer options when increasing max', () => {
-    const longOption =
-      'Correr hacia la montaña lejana durante la tormenta eléctrica que se aproxima rápidamente y nos amenaza con su furia incontrolable';
-    const { valid } = validateOptions([longOption], 1, 2, 25);
-    expect(valid).toEqual([longOption]);
-  });
-
-  it('recognizes common imperative endings', () => {
-    const options = [
-      'Descifra… el código',
-      'Come la comida',
-      'Apagad las luces',
-      'Proceded con cautela',
-      'Salid de aquí',
-      'Callaos ya',
-      'Caminemos juntos',
-      'Revivamos el momento',
+  it('extracts valid options and reports invalid lines', () => {
+    const lines = [
+      '1. First option',
+      '',
+      'Two',
+      '2. Second option',
+      '3. Third option'
     ];
-    const { valid, discarded } = validateOptions(options, options.length, 1);
-    expect(valid).toEqual(options);
-    expect(discarded).toEqual([]);
+    const { valid, invalid, tooMany, tooFew } = validateOptions(lines, 2);
+    expect(valid).toEqual(['First option', 'Second option']);
+    expect(invalid).toEqual(['', 'Two']);
+    expect(tooMany).toBe(true);
+    expect(tooFew).toBe(false);
+  });
+
+  it('flags when fewer options are provided than expected', () => {
+    const { tooMany, tooFew } = validateOptions(['1. Only option'], 2);
+    expect(tooMany).toBe(false);
+    expect(tooFew).toBe(true);
   });
 });

--- a/lib/optionGuard.ts
+++ b/lib/optionGuard.ts
@@ -1,104 +1,36 @@
-export type OptionDiscard = { option: string; reason: string };
-
-export function normalizeOption(s: string): string {
-  return (s || "").replace(/\s+/g, " ").trim();
-}
-
-function countWords(s: string): number {
-  const m = s.match(/[\p{L}\p{N}]+/gu);
-  return m ? m.length : 0;
-}
-
-export function looksLikeVerbStartEs(s: string): boolean {
-  const firstToken = normalizeOption(s).split(" ")[0] || "";
-  const first = firstToken
-    .toLowerCase()
-    .replace(/^[\p{P}\p{S}]+|[\p{P}\p{S}]+$/gu, "");
-  if (!first) return false;
-  if (/(ar|er|ir)$/.test(first)) return true; // infinitivo
-  const irregularImperatives = [
-    "ve",
-    "haz",
-    "sigue",
-    "entra",
-    "toma",
-    "abre",
-    "mira",
-    "detén",
-    "corre",
-    "huye",
-    "busca",
-    "investiga",
-    "pregunta",
-    "enfrenta",
-    "rompe",
-    "cruza",
-    "sube",
-    "baja",
-    "miente",
-    "confiesa",
-    "llama",
-    "esconde",
-    "revela",
-    "ven",
-    "di",
-    "sal",
-    "pon",
-    "ten",
-    "sé",
-  ];
-  if (irregularImperatives.includes(first)) return true;
-  return /(ad|ed|id|en|emos|amos|a|e|os)$/.test(first);
-}
-
-export function isValidOption(
-  s: string,
-  min = 8,
-  max = 56,
-): { ok: boolean; reason?: string } {
-  const t = normalizeOption(s);
-  const words = countWords(t);
-  if (words < min)
-    return { ok: false, reason: `menos de ${min} palabras` };
-  if (words > max)
-    return { ok: false, reason: `más de ${max} palabras` };
-  //if (!looksLikeVerbStartEs(t))
-    //return { ok: false, reason: "no empieza por verbo" };
-  return { ok: true };
-}
-
-export function dedupeOptions(options: string[]): string[] {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const o of options) {
-    const k = normalizeOption(o).toLowerCase();
-    if (k && !seen.has(k)) {
-      seen.add(k);
-      out.push(normalizeOption(o));
-    }
-  }
-  return out;
-}
-
 export function validateOptions(
   options: string[],
-  N: number,
-  min = 8,
-  max = 56,
-): { valid: string[]; discarded: OptionDiscard[] } {
-  const deduped = dedupeOptions(options);
+  expected: number
+): {
+  valid: string[];
+  invalid: string[];
+  tooMany: boolean;
+  tooFew: boolean;
+} {
   const valid: string[] = [];
-  const discarded: OptionDiscard[] = [];
-  for (const o of deduped) {
-    const { ok, reason } = isValidOption(o, min, max);
-    if (ok) {
-      valid.push(normalizeOption(o));
+  const invalid: string[] = [];
+
+  for (const line of options) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      invalid.push(line);
+      continue;
+    }
+    const match = trimmed.match(/^\d+\.\s+(.+)$/);
+    if (match) {
+      valid.push(match[1].trim());
     } else {
-      discarded.push({ option: normalizeOption(o), reason: reason || "" });
+      invalid.push(line);
     }
   }
+
+  const tooMany = valid.length > expected;
+  const tooFew = valid.length < expected;
+
   return {
-    valid: valid.slice(0, Math.max(0, N | 0 || 0)),
-    discarded,
+    valid: valid.slice(0, expected),
+    invalid,
+    tooMany,
+    tooFew,
   };
 }

--- a/lib/parseStoryResponse.ts
+++ b/lib/parseStoryResponse.ts
@@ -28,14 +28,7 @@ export function parseStoryResponse(text: string, optionsPerDecision: number): Pa
 
   if (!isFinal && optionsBlock) {
     const optLines = optionsBlock.split(/\r?\n/);
-    const parsed = optLines
-      .map(l => {
-        const m = l.match(/^\s*\d+\.\s+(.+?)\s*$/);
-        return m ? m[1] : null;
-      })
-      .filter(Boolean) as string[];
-
-    const { valid } = validateOptions(parsed, optionsPerDecision);
+    const { valid } = validateOptions(optLines, optionsPerDecision);
     options = valid;
   }
 


### PR DESCRIPTION
## Summary
- Replace complex option guard with minimal validator that checks numbered lines and counts the options
- Use new validator in story response parsing
- Update tests to verify extraction, invalid tracking and count flags

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx jest`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b12d521c6083298681e2c21a20aaaf