### PR TITLE
Add strict story response parsing tests

### DIFF
--- a/lib/parseStoryResponse.ts
+++ b/lib/parseStoryResponse.ts
@@ -1,9 +1,15 @@
-import { validateOptions } from "./optionGuard";
+import { validateOptions, OptionDiscard } from "./optionGuard";
 
 export type ParseResult = {
   story: string;
   options: string[];
   isFinal: boolean;
+};
+
+export type ParseStrictResult = ParseResult & {
+  diagnostics: string[];
+  errors: string[];
+  discarded: OptionDiscard[];
 };
 
 // Split exacto por línea '---'.
@@ -40,4 +46,86 @@ export function parseStoryResponse(text: string, optionsPerDecision: number): Pa
   }
 
   return { story, options, isFinal };
+}
+
+export function parseStoryResponseStrict(
+  text: string,
+  optionsPerDecision: number,
+  optionMinWords = 8,
+  optionMaxWords = 56,
+): ParseStrictResult {
+  const diagnostics: string[] = [];
+  const errors: string[] = [];
+
+  const raw = text || "";
+
+  if (/\n\s*$/.test(raw)) diagnostics.push("trailing blank lines");
+  if (/#/.test(raw)) diagnostics.push("contains #");
+  if (/```/.test(raw)) diagnostics.push("contains ```");
+  if (/\*\*/.test(raw) || /_/.test(raw))
+    diagnostics.push("contains markdown formatting");
+
+  const linesAll = raw.split(/\r?\n/);
+  const finalIdx = linesAll.findIndex(l => l.trim().toUpperCase() === "FINALIZADO");
+  if (finalIdx !== -1 && linesAll.slice(finalIdx + 1).every(l => !l.trim())) {
+    const story = linesAll.slice(0, finalIdx).join("\n").trim();
+    return {
+      story,
+      options: [],
+      isFinal: true,
+      diagnostics,
+      errors: [],
+      discarded: [],
+    };
+  }
+
+  let bodyLines = linesAll;
+  let sepIdx = bodyLines.findIndex(l => l.includes("---"));
+  if (sepIdx !== -1 && bodyLines[sepIdx].trim() !== "---") {
+    diagnostics.push("separator with extra text");
+    sepIdx = -1;
+  }
+
+  let storyLines: string[];
+  let optionLines: string[];
+
+  if (sepIdx === -1) {
+    storyLines = bodyLines;
+    optionLines = [];
+  } else {
+    storyLines = bodyLines.slice(0, sepIdx);
+    optionLines = bodyLines.slice(sepIdx + 1);
+  }
+
+  const story = storyLines.join("\n").trim();
+  const parsedOptions: string[] = [];
+  optionLines.forEach((line, i) => {
+    if (!line.trim()) return;
+    const m = line.match(/^\s*\d+\.\s+(.+?)\s*$/);
+    if (m) parsedOptions.push(m[1]);
+    else diagnostics.push(`invalid option line ${i + 1}`);
+  });
+
+  const { valid, discarded } = validateOptions(
+    parsedOptions,
+    optionsPerDecision,
+    optionMinWords,
+    optionMaxWords,
+  );
+
+  discarded.forEach(d => errors.push(`${d.option}: ${d.reason}`));
+
+  if (valid.length < optionsPerDecision)
+    errors.push(`expected ${optionsPerDecision} options, got ${valid.length}`);
+  if (parsedOptions.length > optionsPerDecision)
+    errors.push(`too many options (${parsedOptions.length})`);
+
+  return {
+    story,
+    options: valid,
+    isFinal: false,
+    diagnostics,
+    errors,
+    discarded,
+  };
 }

--- a/src/parsestoryresponse.test.ts
+++ b/src/parsestoryresponse.test.ts
@@ -1,0 +1,143 @@
+import { parseStoryResponse, parseStoryResponseStrict } from '../lib/parseStoryResponse';
+
+describe('parseStoryResponseStrict compatibility', () => {
+  const N = 2;
+  test('detects final with FINALIZADO and no options', () => {
+    const text = 'El fin de la historia\nFINALIZADO';
+    const legacy = parseStoryResponse(text, N);
+    const strict = parseStoryResponseStrict(text, N);
+    expect(strict).toMatchObject({
+      story: 'El fin de la historia',
+      options: [],
+      isFinal: true,
+    });
+    expect(legacy.isFinal).toBe(true);
+    expect(legacy.options).toEqual([]);
+    expect(strict.errors).toHaveLength(0);
+  });
+
+  test('non-final text with standalone separator and N options', () => {
+    const text = [
+      'Un relato épico',
+      '---',
+      '1. Explorar el oscuro bosque lleno de misterios ocultos',
+      '2. Investigar las ruinas antiguas que guardan secretos olvidados',
+    ].join('\n');
+    const legacy = parseStoryResponse(text, N);
+    const strict = parseStoryResponseStrict(text, N);
+    expect(strict.story).toBe('Un relato épico');
+    expect(strict.options.length).toBe(2);
+    expect(strict.errors).toHaveLength(0);
+    expect(strict.diagnostics).toHaveLength(0);
+    expect(legacy).toEqual({
+      story: 'Un relato épico',
+      options: [
+        'Explorar el oscuro bosque lleno de misterios ocultos',
+        'Investigar las ruinas antiguas que guardan secretos olvidados',
+      ],
+      isFinal: false,
+    });
+  });
+
+  test('option line not matching pattern is diagnostic', () => {
+    const text = [
+      'Historia inicial',
+      '---',
+      '1 Opción mal formateada',
+      '2. Seguir caminando en silencio por el camino estrecho',
+    ].join('\n');
+    const legacy = parseStoryResponse(text, N);
+    const strict = parseStoryResponseStrict(text, N);
+    expect(strict.diagnostics).toEqual(expect.arrayContaining(['invalid option line 1']));
+    expect(strict.errors).toEqual(expect.arrayContaining(['expected 2 options, got 1']));
+    expect(legacy.options).toEqual(['Seguir caminando en silencio por el camino estrecho']);
+  });
+
+  test('too few options produces error', () => {
+    const text = [
+      'Solo una opción',
+      '---',
+      '1. Adentrarse en la cueva misteriosa con mucha cautela',
+    ].join('\n');
+    const legacy = parseStoryResponse(text, N);
+    const strict = parseStoryResponseStrict(text, N);
+    expect(strict.errors).toEqual(expect.arrayContaining(['expected 2 options, got 1']));
+    expect(legacy.options.length).toBe(1);
+  });
+
+  test('too many options produces error', () => {
+    const text = [
+      'Varias opciones',
+      '---',
+      '1. Explorar el bosque oscuro buscando nuevas aventuras peligrosas',
+      '2. Investigar el castillo abandonado en la distante colina solitaria',
+      '3. Preguntar al sabio anciano sobre el destino incierto del viajero',
+    ].join('\n');
+    const legacy = parseStoryResponse(text, N);
+    const strict = parseStoryResponseStrict(text, N);
+    expect(strict.errors).toEqual(expect.arrayContaining(['too many options (3)']));
+    expect(strict.options.length).toBe(2);
+    expect(legacy.options.length).toBe(2);
+  });
+
+  test('markdown artifacts are reported in diagnostics', () => {
+    const text = [
+      '# Encabezado extraño',
+      '```code```',
+      '---',
+      '1. Seguir el camino **oscuro** entre los árboles _susurrantes_ atentos',
+      '2. Tomar la ruta alternativa para evitar los peligros nocturnos',
+    ].join('\n');
+    const strict = parseStoryResponseStrict(text, N);
+    expect(strict.diagnostics).toEqual(
+      expect.arrayContaining([
+        'contains #',
+        'contains ```',
+        'contains markdown formatting',
+      ]),
+    );
+  });
+
+  test('trailing blank lines trigger diagnostic', () => {
+    const text = [
+      'Narración interesante',
+      '---',
+      '1. Continuar hacia la montaña en búsqueda de respuestas antiguas',
+      '2. Esperar pacientemente junto al río observando las estrellas brillantes',
+      '',
+      '',
+    ].join('\n');
+    const strict = parseStoryResponseStrict(text, N);
+    expect(strict.diagnostics).toEqual(expect.arrayContaining(['trailing blank lines']));
+  });
+
+  test('separator with extra text produces diagnostic and missing options error', () => {
+    const text = [
+      'Cuento corto',
+      '--- opc',
+      '1. Investigar el bosque silencioso en la noche estrellada',
+    ].join('\n');
+    const legacy = parseStoryResponse(text, 1);
+    const strict = parseStoryResponseStrict(text, 1);
+    expect(strict.diagnostics).toEqual(expect.arrayContaining(['separator with extra text']));
+    expect(strict.errors).toEqual(expect.arrayContaining(['expected 1 options, got 0']));
+    expect(legacy.options).toEqual([]);
+  });
+
+  test('word-count bounds enforce min and max', () => {
+    const text = [
+      'Historia',
+      '---',
+      '1. Ir rápido',
+      '2. Caminar lentamente por el sendero serpenteante bajo la luz de la luna y las estrellas brillantes del cielo nocturno',
+    ].join('\n');
+    const strict = parseStoryResponseStrict(text, N, 8, 16);
+    expect(strict.errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('menos de 8 palabras'),
+        expect.stringContaining('más de 16 palabras'),
+        'expected 2 options, got 0',
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- expand story response parser with strict variant returning diagnostics and validation errors
- add comprehensive tests covering FINALIZADO handling, option validation, markdown artifacts, and more

## Testing
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68b12d545998832982689d8e3400e32a