### PR TITLE
Refine story response parsing

### DIFF
--- a/lib/parseStoryResponse.ts
+++ b/lib/parseStoryResponse.ts
@@ -1,5 +1,3 @@
-import { validateOptions, OptionDiscard } from "./optionGuard";
-
 export type ParseResult = {
   story: string;
   options: string[];
@@ -9,12 +7,21 @@ export type ParseResult = {
 export type ParseStrictResult = ParseResult & {
   diagnostics: string[];
   errors: string[];
-  discarded: OptionDiscard[];
 };
 
-// Split exacto por línea '---'.
-function splitStoryAndOptions(text: string): { story: string; optionsBlock: string | null } {
-  const lines = (text || "").split(/\r?\n/);
+function normalizeRaw(raw: string): { text: string; trailingBlankLines: number } {
+  const text = (raw || "").replace(/\r\n/g, "\n");
+  const match = text.match(/\n+$/);
+  const trailingBlankLines = match ? match[0].split(/\n/).length - 1 : 0;
+  return { text: text.trimEnd(), trailingBlankLines };
+}
+
+function splitStoryAndOptionsNormalized(text: string): {
+  story: string;
+  optionsBlock: string | null;
+  separatorLine: string | null;
+} {
+  const lines = (text || "").split(/\n/);
   const idx = lines.findIndex(l => l.trim() === "---");
   if (idx === -1) return { story: text.trim(), optionsBlock: null, separatorLine: null };
   const story = lines.slice(0, idx).join("\n").trimEnd();
@@ -22,10 +29,7 @@ function splitStoryAndOptions(text: string): { story: string; optionsBlock: stri
   return { story, optionsBlock, separatorLine: lines[idx] };
 }
 
-function extractOptions(block: string): {
-  options: string[];
-  diagnostics: string[];
-} {
+function extractOptions(block: string): { options: string[]; diagnostics: string[] } {
   const lines = block.split("\n");
   const options: string[] = [];
   const diagnostics: string[] = [];
@@ -45,12 +49,16 @@ function extractOptions(block: string): {
   return { options, diagnostics };
 }
 
+function countWords(text: string): number {
+  return (text.trim().match(/\S+/g) || []).length;
+}
+
 export function parseStoryResponseStrict(
   raw: string,
   optionsPerDecision: number,
   optionMinWords?: number,
   optionMaxWords?: number,
-): ParseResultStrict {
+): ParseStrictResult {
   const errors: string[] = [];
   const diagnostics: string[] = [];
 
@@ -58,10 +66,13 @@ export function parseStoryResponseStrict(
   if (trailingBlankLines) diagnostics.push("trailing blank lines");
   if (/`{3}|^\s*[-*#]/m.test(normalized)) diagnostics.push("markdown hints");
 
-  if (!isFinal && optionsBlock) {
-    const optLines = optionsBlock.split(/\r?\n/);
-    const { valid } = validateOptions(optLines, optionsPerDecision);
-    options = valid;
+  let working = normalized;
+  let isFinal = false;
+  const lines = working.split(/\n/);
+  if (lines.length && lines[lines.length - 1].trim().toUpperCase() === "FINALIZADO") {
+    isFinal = true;
+    lines.pop();
+    working = lines.join("\n").trimEnd();
   }
 
   const { story, optionsBlock, separatorLine } = splitStoryAndOptionsNormalized(working);
@@ -110,16 +121,6 @@ export function parseStoryResponseStrict(
 export function parseStoryResponse(
   text: string,
   optionsPerDecision: number,
-): ParseResult;
-export function parseStoryResponse(
-  text: string,
-  optionsPerDecision: number,
-  optionMinWords?: number,
-  optionMaxWords?: number,
-): ParseResult;
-export function parseStoryResponse(
-  text: string,
-  optionsPerDecision: number,
   optionMinWords?: number,
   optionMaxWords?: number,
 ): ParseResult {
@@ -130,86 +131,4 @@ export function parseStoryResponse(
     optionMaxWords,
   );
   return { story, options, isFinal };
-}
-
-export function parseStoryResponseStrict(
-  text: string,
-  optionsPerDecision: number,
-  optionMinWords = 8,
-  optionMaxWords = 56,
-): ParseStrictResult {
-  const diagnostics: string[] = [];
-  const errors: string[] = [];
-
-  const raw = text || "";
-
-  if (/\n\s*$/.test(raw)) diagnostics.push("trailing blank lines");
-  if (/#/.test(raw)) diagnostics.push("contains #");
-  if (/```/.test(raw)) diagnostics.push("contains ```");
-  if (/\*\*/.test(raw) || /_/.test(raw))
-    diagnostics.push("contains markdown formatting");
-
-  const linesAll = raw.split(/\r?\n/);
-  const finalIdx = linesAll.findIndex(l => l.trim().toUpperCase() === "FINALIZADO");
-  if (finalIdx !== -1 && linesAll.slice(finalIdx + 1).every(l => !l.trim())) {
-    const story = linesAll.slice(0, finalIdx).join("\n").trim();
-    return {
-      story,
-      options: [],
-      isFinal: true,
-      diagnostics,
-      errors: [],
-      discarded: [],
-    };
-  }
-
-  let bodyLines = linesAll;
-  let sepIdx = bodyLines.findIndex(l => l.includes("---"));
-  if (sepIdx !== -1 && bodyLines[sepIdx].trim() !== "---") {
-    diagnostics.push("separator with extra text");
-    sepIdx = -1;
-  }
-
-  let storyLines: string[];
-  let optionLines: string[];
-
-  if (sepIdx === -1) {
-    storyLines = bodyLines;
-    optionLines = [];
-  } else {
-    storyLines = bodyLines.slice(0, sepIdx);
-    optionLines = bodyLines.slice(sepIdx + 1);
-  }
-
-  const story = storyLines.join("\n").trim();
-  const parsedOptions: string[] = [];
-  optionLines.forEach((line, i) => {
-    if (!line.trim()) return;
-    const m = line.match(/^\s*\d+\.\s+(.+?)\s*$/);
-    if (m) parsedOptions.push(m[1]);
-    else diagnostics.push(`invalid option line ${i + 1}`);
-  });
-
-  const { valid, discarded } = validateOptions(
-    parsedOptions,
-    optionsPerDecision,
-    optionMinWords,
-    optionMaxWords,
-  );
-
-  discarded.forEach(d => errors.push(`${d.option}: ${d.reason}`));
-
-  if (valid.length < optionsPerDecision)
-    errors.push(`expected ${optionsPerDecision} options, got ${valid.length}`);
-  if (parsedOptions.length > optionsPerDecision)
-    errors.push(`too many options (${parsedOptions.length})`);
-
-  return {
-    story,
-    options: valid,
-    isFinal: false,
-    diagnostics,
-    errors,
-    discarded,
-  };
 }


### PR DESCRIPTION
## Summary
- Normalize responses, detect trailing `FINALIZADO`, and split story from options
- Parse options only when needed and validate formatting

## Testing
- `npx jest __tests__/parseStoryResponse.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2566f21e4832984cbf3d5d4b19297