### PR TITLE
Handle SD API fetch errors

### DIFF
--- a/app/api/sd/generate/route.ts
+++ b/app/api/sd/generate/route.ts
@@ -6,28 +6,40 @@ export async function POST(req: Request) {
   const SD_API = process.env.SD_API_URL 
     ?? "https://tbhvrp51-8000.brs.devtunnels.ms";
 
-  const r = await fetch(SD_API, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-    // Importante: no enviar credenciales para evitar CORS raros
-  });
+  try {
+    const r = await fetch(SD_API, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      // Importante: no enviar credenciales para evitar CORS raros
+    });
 
-  const text = await r.text();
-  if (!r.ok) {
+    const text = await r.text();
+    if (!r.ok) {
+      return new Response(
+        JSON.stringify({ error: text || "SD API error" }),
+        { status: r.status, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    // Tu API devuelve { image_base64 }
+    const { image_base64 } = JSON.parse(text);
+    const image_url = `data:image/png;base64,${image_base64}`;
+
+    // Devolvemos también data[0].url para compatibilidad "OpenAI-style"
     return new Response(
-      JSON.stringify({ error: text || "SD API error" }),
-      { status: r.status, headers: { "Content-Type": "application/json" } }
+      JSON.stringify({ image_base64, image_url, data: [{ url: image_url }] }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({
+        error:
+          error instanceof Error
+            ? error.message
+            : "Error fetching SD API",
+      }),
+      { status: 502, headers: { "Content-Type": "application/json" } }
     );
   }
-
-  // Tu API devuelve { image_base64 }
-  const { image_base64 } = JSON.parse(text);
-  const image_url = `data:image/png;base64,${image_base64}`;
-
-  // Devolvemos también data[0].url para compatibilidad "OpenAI-style"
-  return new Response(
-    JSON.stringify({ image_base64, image_url, data: [{ url: image_url }] }),
-    { status: 200, headers: { "Content-Type": "application/json" } }
-  );
 }


### PR DESCRIPTION
## Summary
- wrap SD API fetch in try/catch
- return HTTP 502 with descriptive error when fetch fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b64f5203c48329b13edc12c09bc113