### PR TITLE
feat: add prompt routes

### DIFF
--- a/app/api/prompt/generate/route.ts
+++ b/app/api/prompt/generate/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import createChatCompletion from "@/lib/groqClient";
+
+export async function POST(req: Request) {
+  if (!process.env.GROQ_API_KEY) {
+    return NextResponse.json(
+      { error: "GROQ_API_KEY is not configured" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { config } = await req.json();
+    if (!config) {
+      return NextResponse.json(
+        { error: "config is required" },
+        { status: 400 }
+      );
+    }
+
+    const model = process.env.GROQ_MODEL || "openai/gpt-oss-120b";
+    const completion = await createChatCompletion({
+      model,
+      messages: [
+        {
+          role: "system",
+          content:
+            "Genera una semilla de historia creativa basada en la configuración proporcionada.",
+        },
+        { role: "user", content: JSON.stringify(config) },
+      ],
+    });
+
+    const prompt = completion.choices[0]?.message?.content?.trim();
+    if (!prompt) {
+      throw new Error("Empty response from model");
+    }
+
+    return NextResponse.json({ prompt });
+  } catch (err) {
+    console.error("generate prompt error:", err);
+    return NextResponse.json(
+      { error: "Error generating prompt" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/app/api/prompt/improve/route.ts
+++ b/app/api/prompt/improve/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import createChatCompletion from "@/lib/groqClient";
+
+export async function POST(req: Request) {
+  if (!process.env.GROQ_API_KEY) {
+    return NextResponse.json(
+      { error: "GROQ_API_KEY is not configured" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { prompt } = await req.json();
+    if (!prompt || typeof prompt !== "string") {
+      return NextResponse.json(
+        { error: "prompt is required" },
+        { status: 400 }
+      );
+    }
+
+    const model = process.env.GROQ_MODEL || "openai/gpt-oss-120b";
+    const completion = await createChatCompletion({
+      model,
+      messages: [
+        {
+          role: "system",
+          content:
+            "Eres un asistente que mejora prompts manteniendo la intención original.",
+        },
+        { role: "user", content: prompt },
+      ],
+    });
+
+    const improved = completion.choices[0]?.message?.content?.trim();
+    if (!improved) {
+      throw new Error("Empty response from model");
+    }
+
+    return NextResponse.json({ prompt: improved });
+  } catch (err) {
+    console.error("improve prompt error:", err);
+    return NextResponse.json(
+      { error: "Error improving prompt" },
+      { status: 500 }
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add API endpoint to improve prompts via Groq
- add API endpoint to generate prompts from configuration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b75aad520c8329ad81aef458270da6