### PR TITLE
Add prompt action translations and buttons

### DIFF
--- a/__tests__/storyFormMissingOptions.test.tsx
+++ b/__tests__/storyFormMissingOptions.test.tsx
@@ -24,6 +24,10 @@ describe('StoryForm fetches missing options', () => {
       .fn()
       .mockResolvedValueOnce({
         ok: true,
+        json: () => Promise.resolve({ top: [], bottom: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ text: initialText }),
       })
       .mockResolvedValueOnce({

--- a/__tests__/storyMissingOptions.test.tsx
+++ b/__tests__/storyMissingOptions.test.tsx
@@ -18,6 +18,7 @@ describe('Story options regeneration', () => {
     (global.fetch as jest.Mock) = jest
       .fn()
       .mockResolvedValueOnce({
+        ok: true,
         json: () =>
           Promise.resolve({
             story: 'Nuevo capítulo',
@@ -26,6 +27,7 @@ describe('Story options regeneration', () => {
           }),
       })
       .mockResolvedValueOnce({
+        ok: true,
         json: () =>
           Promise.resolve({
             options: ['Investigar las antiguas ruinas de la ciudad perdida'],

--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -336,6 +336,22 @@ export default function StoryForm() {
               <span>{tokenCount}/{TOKEN_LIMIT} tokens</span>
               {tokenCount >= TOKEN_LIMIT && (<span className="text-red-600">Límite alcanzado</span>)}
             </div>
+            <div className="flex gap-2 mt-2">
+              <button
+                type="button"
+                onClick={() => {}}
+                className="px-2 py-1 text-sm rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark"
+              >
+                {t("improvePrompt")}
+              </button>
+              <button
+                type="button"
+                onClick={() => {}}
+                className="px-2 py-1 text-sm rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark"
+              >
+                {t("generatePrompt")}
+              </button>
+            </div>
           </div>
 
           {/* 2) Géneros debajo del textarea */}

--- a/public/locales/en-US/messages.json
+++ b/public/locales/en-US/messages.json
@@ -1,6 +1,8 @@
 {
   "StoryForm": {
     "randomize": "Randomize",
+    "improvePrompt": "Improve Prompt",
+    "generatePrompt": "Generate Prompt",
     "createStory": "Create story",
     "sending": "Sending...",
     "promptTruncated": "Your prompt was truncated to the limit of {limit} tokens."

--- a/public/locales/en/messages.json
+++ b/public/locales/en/messages.json
@@ -1,6 +1,8 @@
 {
   "StoryForm": {
     "randomize": "Randomize",
+    "improvePrompt": "Improve Prompt",
+    "generatePrompt": "Generate Prompt",
     "createStory": "Create story",
     "sending": "Sending...",
     "promptTruncated": "Your prompt was truncated to the limit of {limit} tokens."

--- a/public/locales/es-AR/messages.json
+++ b/public/locales/es-AR/messages.json
@@ -1,6 +1,8 @@
 {
   "StoryForm": {
     "randomize": "Randomizar",
+    "improvePrompt": "Mejorar Prompt",
+    "generatePrompt": "Generar Prompt",
     "createStory": "Crear historia",
     "sending": "Enviando...",
     "promptTruncated": "Tu prompt fue recortado al límite de {limit} tokens."

--- a/public/locales/es-MX/messages.json
+++ b/public/locales/es-MX/messages.json
@@ -1,6 +1,8 @@
 {
   "StoryForm": {
     "randomize": "Randomizar",
+    "improvePrompt": "Mejorar Prompt",
+    "generatePrompt": "Generar Prompt",
     "createStory": "Crear historia",
     "sending": "Enviando...",
     "promptTruncated": "Tu prompt fue recortado al límite de {limit} tokens."

--- a/public/locales/es/messages.json
+++ b/public/locales/es/messages.json
@@ -1,6 +1,8 @@
 {
   "StoryForm": {
     "randomize": "Randomizar",
+    "improvePrompt": "Mejorar Prompt",
+    "generatePrompt": "Generar Prompt",
     "createStory": "Crear historia",
     "sending": "Enviando...",
     "promptTruncated": "Tu prompt fue recortado al límite de {limit} tokens."

--- a/public/locales/fr-FR/messages.json
+++ b/public/locales/fr-FR/messages.json
@@ -1,6 +1,8 @@
 {
   "StoryForm": {
     "randomize": "Randomize",
+    "improvePrompt": "Améliorer le prompt",
+    "generatePrompt": "Générer le prompt",
     "createStory": "Create story",
     "sending": "Sending...",
     "promptTruncated": "Your prompt was truncated to the limit of {limit} tokens."

--- a/public/locales/neutral/messages.json
+++ b/public/locales/neutral/messages.json
@@ -1,6 +1,8 @@
 {
   "StoryForm": {
     "randomize": "Randomizar",
+    "improvePrompt": "Mejorar Prompt",
+    "generatePrompt": "Generar Prompt",
     "createStory": "Crear historia",
     "sending": "Enviando...",
     "promptTruncated": "Tu prompt fue recortado al límite de {limit} tokens."


### PR DESCRIPTION
## Summary
- add `improvePrompt` and `generatePrompt` strings to all locale message files
- show new buttons in `StoryForm` using `useTranslations('StoryForm')`
- adjust tests to mock background fetch and include `ok` status in responses

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68b75aaede1c8329b3853a082e10727f