### PR TITLE
test: add prompt buttons tests

### DIFF
--- a/__tests__/promptButtons.test.tsx
+++ b/__tests__/promptButtons.test.tsx
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('../app/components/Story', () => () => null);
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+jest.mock('../app/providers/LanguageProvider', () => ({
+  useLanguage: () => ({ locale: 'es' }),
+}));
+
+import StoryForm from '../app/components/StoryForm';
+
+describe('StoryForm prompt buttons', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock) = jest.fn((url: string) => {
+      if (url === '/api/backgrounds') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ top: [], bottom: [] }),
+        });
+      }
+      if (url === '/api/prompt/1') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ text: 'Primer prompt' }),
+        });
+      }
+      if (url === '/api/prompt/2') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ text: 'Segundo prompt' }),
+        });
+      }
+      return Promise.reject(new Error('Unknown endpoint'));
+    }) as jest.Mock;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('muestra botones y actualiza el textarea con cada endpoint', async () => {
+    render(<StoryForm />);
+
+    const prompt1 = screen.getByRole('button', { name: 'Prompt 1' });
+    const prompt2 = screen.getByRole('button', { name: 'Prompt 2' });
+
+    expect(prompt1).toBeInTheDocument();
+    expect(prompt2).toBeInTheDocument();
+
+    fireEvent.click(prompt1);
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/prompt/1');
+      expect(screen.getByPlaceholderText('Escribe el inicio de la historia')).toHaveValue('Primer prompt');
+    });
+
+    fireEvent.click(prompt2);
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/prompt/2');
+      expect(screen.getByPlaceholderText('Escribe el inicio de la historia')).toHaveValue('Segundo prompt');
+    });
+  });
+});

--- a/__tests__/randomizeButton.test.tsx
+++ b/__tests__/randomizeButton.test.tsx
@@ -12,6 +12,17 @@ jest.mock('../app/providers/LanguageProvider', () => ({
 import StoryForm from '../app/components/StoryForm';
 
 describe('StoryForm randomizer', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ top: [], bottom: [] }),
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   test('muestra botón Randomizar', () => {
     render(<StoryForm />);
     expect(screen.getByRole('button', { name: /randomize/i })).toBeInTheDocument();

--- a/__tests__/storyFormMissingOptions.test.tsx
+++ b/__tests__/storyFormMissingOptions.test.tsx
@@ -24,6 +24,10 @@ describe('StoryForm fetches missing options', () => {
       .fn()
       .mockResolvedValueOnce({
         ok: true,
+        json: () => Promise.resolve({ top: [], bottom: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: () => Promise.resolve({ text: initialText }),
       })
       .mockResolvedValueOnce({

--- a/__tests__/storyMissingOptions.test.tsx
+++ b/__tests__/storyMissingOptions.test.tsx
@@ -18,6 +18,7 @@ describe('Story options regeneration', () => {
     (global.fetch as jest.Mock) = jest
       .fn()
       .mockResolvedValueOnce({
+        ok: true,
         json: () =>
           Promise.resolve({
             story: 'Nuevo capítulo',
@@ -26,6 +27,7 @@ describe('Story options regeneration', () => {
           }),
       })
       .mockResolvedValueOnce({
+        ok: true,
         json: () =>
           Promise.resolve({
             options: ['Investigar las antiguas ruinas de la ciudad perdida'],

--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -174,6 +174,21 @@ export default function StoryForm() {
     setConfig({ generos: [genero], estilo, ajustes });
   };
 
+  const fetchPrompt = async (endpoint: string) => {
+    try {
+      const res = await fetch(endpoint);
+      const data = await res.json().catch(() => ({}));
+      const text: string = typeof data?.text === "string" ? data.text : "";
+      if (text) {
+        setPrompt(text);
+        setTokenCount(countTokens(text));
+        setPromptTruncated(false);
+      }
+    } catch (err) {
+      console.error("Error fetching prompt", err);
+    }
+  };
+
   const handleSubmit = async () => {
     setLoading(true);
     setError(null);
@@ -321,6 +336,22 @@ export default function StoryForm() {
         <>
           {/* 1) Texto inicial */}
           <div className="flex flex-col w-full max-w-xl">
+            <div className="flex gap-2 mb-2">
+              <button
+                type="button"
+                onClick={() => fetchPrompt("/api/prompt/1")}
+                className="px-2 py-1 text-sm rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark"
+              >
+                Prompt 1
+              </button>
+              <button
+                type="button"
+                onClick={() => fetchPrompt("/api/prompt/2")}
+                className="px-2 py-1 text-sm rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark"
+              >
+                Prompt 2
+              </button>
+            </div>
             <textarea
               className="w-full p-2 border border-black/30 hover:border-black/60 rounded-lg focus:ring-2 focus:ring-accent"
               placeholder="Escribe el inicio de la historia"


### PR DESCRIPTION
## Summary
- add buttons to load sample prompts in `StoryForm`
- test prompt buttons fetching and textarea updates
- adjust existing tests to mock background and option fetches

## Testing
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68b75ab0442483298cf557782bec4063