### PR TITLE
refactor: remove duplicate prompt buttons

### DIFF
--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -394,45 +394,13 @@ export default function StoryForm() {
                 disabled={loading}
                 className="px-2 py-1 text-sm rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark disabled:opacity-50"
               >
-                Mejorar Prompt
+                {t("improvePrompt")}
               </button>
               <button
                 type="button"
                 onClick={handleGeneratePrompt}
                 disabled={loading}
                 className="px-2 py-1 text-sm rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark disabled:opacity-50"
-              >
-                Generar Prompt
-              </button>
-            </div>
-            <div className="flex gap-2 mt-2">
-              <button
-                type="button"
-                onClick={() => {}}
-                className="px-2 py-1 text-sm rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark"
-              >
-                {t("improvePrompt")}
-              </button>
-              <button
-                type="button"
-                onClick={() => {}}
-                className="px-2 py-1 text-sm rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark"
-              >
-                {t("generatePrompt")}
-              </button>
-            </div>
-            <div className="flex gap-2 mt-2">
-              <button
-                type="button"
-                onClick={() => {}}
-                className="px-2 py-1 text-sm rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark"
-              >
-                {t("improvePrompt")}
-              </button>
-              <button
-                type="button"
-                onClick={() => {}}
-                className="px-2 py-1 text-sm rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark"
               >
                 {t("generatePrompt")}
               </button>


### PR DESCRIPTION
## Summary
- remove duplicate prompt action buttons
- use localized text for prompt improvement buttons

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b76071c4048329a505e6d592092a7d