### PR TITLE
Remove prompt fetch buttons from StoryForm

### DIFF
--- a/__tests__/promptActions.test.tsx
+++ b/__tests__/promptActions.test.tsx
@@ -12,7 +12,7 @@ jest.mock('../app/providers/LanguageProvider', () => ({
 
 import StoryForm from '../app/components/StoryForm';
 
-describe('StoryForm prompt buttons', () => {
+describe('StoryForm prompt actions', () => {
   beforeEach(() => {
     (global.fetch as jest.Mock) = jest.fn((url: string) => {
       if (url === '/api/backgrounds') {
@@ -21,16 +21,16 @@ describe('StoryForm prompt buttons', () => {
           json: () => Promise.resolve({ top: [], bottom: [] }),
         });
       }
-      if (url === '/api/prompt/1') {
+      if (url === '/api/prompt/improve') {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ text: 'Primer prompt' }),
+          json: () => Promise.resolve({ text: 'Prompt mejorado' }),
         });
       }
-      if (url === '/api/prompt/2') {
+      if (url === '/api/prompt/generate') {
         return Promise.resolve({
           ok: true,
-          json: () => Promise.resolve({ text: 'Segundo prompt' }),
+          json: () => Promise.resolve({ text: 'Prompt generado' }),
         });
       }
       return Promise.reject(new Error('Unknown endpoint'));
@@ -41,25 +41,23 @@ describe('StoryForm prompt buttons', () => {
     jest.resetAllMocks();
   });
 
-  it('muestra botones y actualiza el textarea con cada endpoint', async () => {
+  it('mejora y genera prompts desde la API', async () => {
     render(<StoryForm />);
 
-    const prompt1 = screen.getByRole('button', { name: 'Prompt 1' });
-    const prompt2 = screen.getByRole('button', { name: 'Prompt 2' });
+    const textarea = screen.getByPlaceholderText('Escribe el inicio de la historia');
 
-    expect(prompt1).toBeInTheDocument();
-    expect(prompt2).toBeInTheDocument();
+    fireEvent.change(textarea, { target: { value: 'Inicio' } });
 
-    fireEvent.click(prompt1);
+    fireEvent.click(screen.getByRole('button', { name: 'improvePrompt' }));
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith('/api/prompt/1');
-      expect(screen.getByPlaceholderText('Escribe el inicio de la historia')).toHaveValue('Primer prompt');
+      expect(global.fetch).toHaveBeenCalledWith('/api/prompt/improve', expect.any(Object));
+      expect(textarea).toHaveValue('Prompt mejorado');
     });
 
-    fireEvent.click(prompt2);
+    fireEvent.click(screen.getByRole('button', { name: 'generatePrompt' }));
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith('/api/prompt/2');
-      expect(screen.getByPlaceholderText('Escribe el inicio de la historia')).toHaveValue('Segundo prompt');
+      expect(global.fetch).toHaveBeenCalledWith('/api/prompt/generate', expect.any(Object));
+      expect(textarea).toHaveValue('Prompt generado');
     });
   });
 });

--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -193,21 +193,6 @@ export default function StoryForm() {
     setConfig({ generos: [genero], estilo, ajustes });
   };
 
-  const fetchPrompt = async (endpoint: string) => {
-    try {
-      const res = await fetch(endpoint);
-      const data = await res.json().catch(() => ({}));
-      const text: string = typeof data?.text === "string" ? data.text : "";
-      if (text) {
-        setPrompt(text);
-        setTokenCount(countTokens(text));
-        setPromptTruncated(false);
-      }
-    } catch (err) {
-      console.error("Error fetching prompt", err);
-    }
-  };
-
   const handleImprovePrompt = async () => {
     setLoading(true);
     setError(null);
@@ -408,24 +393,8 @@ export default function StoryForm() {
         <>
           {/* 1) Texto inicial */}
           <div className="flex flex-col w-full max-w-xl">
-            <div className="flex gap-2 mb-2">
-              <button
-                type="button"
-                onClick={() => fetchPrompt("/api/prompt/1")}
-                className="px-2 py-1 text-sm rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark"
-              >
-                Prompt 1
-              </button>
-              <button
-                type="button"
-                onClick={() => fetchPrompt("/api/prompt/2")}
-                className="px-2 py-1 text-sm rounded-lg bg-accent text-black border border-black/30 hover:border-black/60 hover:bg-accent-dark"
-              >
-                Prompt 2
-              </button>
-            </div>
             <textarea
-              className="w-full p-2 border border-black/30 hover:border-black/60 rounded-lg focus:ring-2 focus:ring-accent"
+              className="w-full p-2 mb-2 border border-black/30 hover:border-black/60 rounded-lg focus:ring-2 focus:ring-accent"
               placeholder="Escribe el inicio de la historia"
               value={prompt}
               onChange={(e) => {


### PR DESCRIPTION
## Summary
- remove fetchPrompt helper and demo prompt buttons
- adjust StoryForm layout so textarea stands alone
- replace prompt button test with API action coverage

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68b7644c8440832995ed33e630f67645