### PR TITLE
Handle empty improve prompt and adjust API response field

### DIFF
--- a/__tests__/improvePrompt.test.tsx
+++ b/__tests__/improvePrompt.test.tsx
@@ -1,0 +1,61 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('../app/components/Story', () => () => null);
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+jest.mock('../app/providers/LanguageProvider', () => ({
+  useLanguage: () => ({ locale: 'es' }),
+}));
+
+import StoryForm from '../app/components/StoryForm';
+
+describe('StoryForm improve prompt', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock) = jest.fn((url: string) => {
+      if (url === '/api/backgrounds') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ top: [], bottom: [] }),
+        });
+      }
+      if (url === '/api/prompt/improve') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ prompt: 'Texto mejorado' }),
+        });
+      }
+      return Promise.reject(new Error('Unknown endpoint'));
+    }) as jest.Mock;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('llama al endpoint y actualiza el textarea', async () => {
+    render(<StoryForm />);
+
+    const textarea = screen.getByPlaceholderText('Escribe el inicio de la historia');
+    fireEvent.change(textarea, { target: { value: 'texto' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'improvePrompt' }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/prompt/improve', expect.any(Object));
+      expect(textarea).toHaveValue('Texto mejorado');
+      expect(screen.getByText('2/500 tokens')).toBeInTheDocument();
+    });
+  });
+
+  it('no hace nada si el textarea está vacío', () => {
+    render(<StoryForm />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'improvePrompt' }));
+
+    expect(global.fetch).toHaveBeenCalledTimes(1); // solo /api/backgrounds
+    expect(global.fetch).not.toHaveBeenCalledWith('/api/prompt/improve', expect.anything());
+  });
+});

--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -209,6 +209,7 @@ export default function StoryForm() {
   };
 
   const handleImprovePrompt = async () => {
+    if (!prompt.trim()) return;
     setLoading(true);
     setError(null);
     try {
@@ -222,9 +223,9 @@ export default function StoryForm() {
         const errMsg = typeof data?.error === 'string' ? data.error : 'Error al mejorar el prompt';
         throw new Error(errMsg);
       }
-      const text: string = typeof data?.text === 'string' ? data.text : '';
-      const tokens = countTokens(text);
-      setPrompt(text);
+      const improvedPrompt: string = typeof data?.prompt === 'string' ? data.prompt : '';
+      const tokens = countTokens(improvedPrompt);
+      setPrompt(improvedPrompt);
       setTokenCount(tokens);
       setPromptTruncated(tokens > TOKEN_LIMIT);
     } catch (err) {


### PR DESCRIPTION
## Summary
- skip improve request if prompt is blank
- read `prompt` from improve API and update token state
- add tests for improving prompt and empty input

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68b76450d5a88329a726f7dfc85651c1