### PR TITLE
Use new prompt field when generating prompts

### DIFF
--- a/__tests__/generatePrompt.test.tsx
+++ b/__tests__/generatePrompt.test.tsx
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+jest.mock('../app/components/Story', () => () => null);
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+jest.mock('../app/providers/LanguageProvider', () => ({
+  useLanguage: () => ({ locale: 'es' }),
+}));
+
+import StoryForm from '../app/components/StoryForm';
+
+describe('StoryForm generate prompt', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock) = jest.fn((url: string) => {
+      if (url === '/api/backgrounds') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ top: [], bottom: [] }),
+        });
+      }
+      if (url === '/api/prompt/generate') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ prompt: 'Prompt generado' }),
+        });
+      }
+      return Promise.reject(new Error('Unknown endpoint'));
+    }) as jest.Mock;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('actualiza el textarea al generar un prompt', async () => {
+    render(<StoryForm />);
+
+    const generateButton = screen.getByRole('button', { name: 'generatePrompt' });
+    fireEvent.click(generateButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/prompt/generate', expect.any(Object));
+      expect(screen.getByPlaceholderText('Escribe el inicio de la historia')).toHaveValue('Prompt generado');
+    });
+  });
+});

--- a/app/components/StoryForm.tsx
+++ b/app/components/StoryForm.tsx
@@ -249,7 +249,7 @@ export default function StoryForm() {
         const errMsg = typeof data?.error === 'string' ? data.error : 'Error al generar el prompt';
         throw new Error(errMsg);
       }
-      const text: string = typeof data?.text === 'string' ? data.text : '';
+      const text = typeof data?.prompt === 'string' ? data.prompt : '';
       const tokens = countTokens(text);
       setPrompt(text);
       setTokenCount(tokens);


### PR DESCRIPTION
## Summary
- read generated prompt from `prompt` field in `handleGeneratePrompt`
- add test to ensure textarea updates after generating a prompt

## Testing
- `npx jest`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b7645385cc8329877196fe66833c47