### PR TITLE
feat: add splash screen for initial loading

### DIFF
--- a/app/components/SplashScreen.tsx
+++ b/app/components/SplashScreen.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import Image from 'next/image';
+
+export default function SplashScreen() {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-[var(--background)]">
+      <Image
+        src="/pluma.svg"
+        alt="TheNoReal logo"
+        width={192}
+        height={192}
+        className="splash-logo"
+        priority
+      />
+    </div>
+  );
+}
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -32,3 +32,19 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@keyframes splash-pulse {
+  0%, 100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.7;
+    transform: scale(1.05);
+  }
+}
+
+.splash-logo {
+  animation: splash-pulse 3s ease-in-out infinite;
+}
+

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,6 @@
+import SplashScreen from './components/SplashScreen';
+
+export default function Loading() {
+  return <SplashScreen />;
+}
+

--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
   "short_name": "TheNoReal",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#fffff0",
-  "theme_color": "#000000",
+  "background_color": "#f5e9ff",
+  "theme_color": "#5dbb63",
   "icons": [
     {
       "src": "/icons/icon-192x192.png",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,8 +3,8 @@
   "short_name": "TheNoReal",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#fffff0",
-  "theme_color": "#000000",
+  "background_color": "#f5e9ff",
+  "theme_color": "#5dbb63",
   "icons": [
     {
       "src": "/icons/icon-192x192.png",


### PR DESCRIPTION
## Summary
- add animated SplashScreen component and loading route
- update global styles with splash animation keyframes
- refresh PWA manifest colors to match app palette

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: sh: 30: eval: [[: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b90b731e68832981565f193a9d56e1